### PR TITLE
Support unencrypted assertions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                wai-saml2
-version:             0.2.1.2
+version:             0.3.0.0
 github:              "mbg/wai-saml2"
 license:             MIT
 author:              "Michael B. Gale"
@@ -15,10 +15,18 @@ extra-source-files:
 - CHANGELOG.md
 
 default-extensions:
-- OverloadedStrings
-- MultiWayIf
-- RecordWildCards
+- ConstraintKinds
+- DataKinds
 - FlexibleInstances
+- KindSignatures
+- MultiParamTypeClasses
+- MultiWayIf
+- OverloadedStrings
+- PolyKinds
+- RecordWildCards
+- TypeApplications
+- TypeFamilies
+- TypeOperators
 
 dependencies:
 - base >= 4.8 && < 5

--- a/src/Network/Wai/SAML2.hs
+++ b/src/Network/Wai/SAML2.hs
@@ -97,9 +97,11 @@ isPOST = (=="POST") . requestMethod
 -- | 'saml2Callback' @config callback@ produces SAML2 'Middleware' for
 -- the given @config@. If the middleware intercepts a request to the 
 -- endpoint given by @config@, the result will be passed to @callback@.
-saml2Callback :: SAML2Config 
-              -> (Either SAML2Error Result -> Middleware)
-              -> Middleware
+saml2Callback 
+    :: HasSaml2Config opts
+    => SAML2Config opts
+    -> (Either SAML2Error Result -> Middleware)
+    -> Middleware
 saml2Callback cfg callback app req sendResponse = do 
     let path = rawPathInfo req 
 
@@ -181,7 +183,7 @@ errorKey :: V.Key SAML2Error
 errorKey = unsafePerformIO V.newKey
 
 -- | 'saml2Vault' @config@ produces SAML2 'Middleware' for the given @config@.
-saml2Vault :: SAML2Config -> Middleware
+saml2Vault :: HasSaml2Config opts => SAML2Config opts -> Middleware
 saml2Vault cfg = saml2Callback cfg callback 
     -- if the middleware intercepts a request containing a SAML2 response at 
     -- the configured endpoint, the outcome of processing response will be

--- a/src/Network/Wai/SAML2/Config.hs
+++ b/src/Network/Wai/SAML2/Config.hs
@@ -7,8 +7,12 @@
 
 -- | Configuration types and smart constructors for the SAML2 middleware.
 module Network.Wai.SAML2.Config (
+    SAML2CfgFlags(..),
     SAML2Config(..),
-    saml2Config
+    saml2Config,
+    saml2PlainTextConfig,
+    HasSaml2Config,
+    SpPrivateKey(..)
 ) where 
 
 --------------------------------------------------------------------------------
@@ -19,14 +23,34 @@ import Crypto.PubKey.RSA
 
 --------------------------------------------------------------------------------
 
+-- | The constructors of this kind enumerate configuration options.
+data SAML2CfgFlags
+    -- | If this flag is set, assertions are expected to be unencyrpted.
+    = PlainTextAssertions
+
+-- | This type family combines type-level @elem@ and @if@ so that 
+-- `CfgHasFlag` @flag opts t f@ will evaluate to @t@ if @opts@ contains
+-- @flag@ or to @f@ otherwise.
+type family CfgHasFlag 
+    (flag :: SAML2CfgFlags) 
+    (opts :: [SAML2CfgFlags]) 
+    (tru :: k)
+    (fls :: k) :: k where
+    CfgHasFlag f '[] tru fls = fls
+    CfgHasFlag f (f ': opts) tru fls = tru
+    CfgHasFlag f (_ ': opts) tru fls = CfgHasFlag f opts tru fls
+
+type CfgPrivateKey opts = 
+    CfgHasFlag 'PlainTextAssertions opts () PrivateKey
+
 -- | Represents configurations for the SAML2 middleware.
-data SAML2Config = SAML2Config {
+data SAML2Config opts = SAML2Config {
     -- | The path relative to the root of the web application at which the
     -- middleware should listen for SAML2 assertions (e.g. /sso/assert).
     saml2AssertionPath :: !BS.ByteString,
     -- | The service provider's private key, used to decrypt data from 
     -- the identity provider.
-    saml2PrivateKey :: !PrivateKey,
+    saml2PrivateKey :: !(CfgPrivateKey opts),
     -- | The identity provider's public key, used to validate
     -- signatures.
     saml2PublicKey :: !PublicKey,
@@ -45,7 +69,7 @@ data SAML2Config = SAML2Config {
 -- with the most basic set of options possible using @privateKey@ as the 
 -- SP's private key and @publicKey@ as the IdP's public key. You should 
 -- almost certainly change the resulting settings.
-saml2Config :: PrivateKey -> PublicKey -> SAML2Config
+saml2Config :: PrivateKey -> PublicKey -> SAML2Config '[]
 saml2Config privKey pubKey = SAML2Config{
     saml2AssertionPath = "/sso/assert",
     saml2PrivateKey = privKey,
@@ -54,5 +78,38 @@ saml2Config privKey pubKey = SAML2Config{
     saml2ExpectedDestination = Nothing,
     saml2DisableTimeValidation = False
 }
+
+-- | `saml2PlainTextConfig` @publicKey@ constructs a `SAML2Config` value with 
+-- the most basic set of options possible. Unlike `saml2Config`, we do not 
+-- require a private key for the SP here and instead expect assertions to be
+-- delivered to us in plain text by the identity provider.
+saml2PlainTextConfig :: PublicKey -> SAML2Config '[PlainTextAssertions]
+saml2PlainTextConfig pubKey = SAML2Config{
+    saml2AssertionPath = "/sso/assert",
+    saml2PrivateKey = (),
+    saml2PublicKey = pubKey,
+    saml2ExpectedIssuer = Nothing,
+    saml2ExpectedDestination = Nothing,
+    saml2DisableTimeValidation = False
+}
+
+-- | A constraint alias for all constraints we can place on the SAML2
+-- configuration. This is primarily used so that we can write safe functions
+-- which can retrieve whatever configuration components are available based
+-- on the type-level configuration.
+type HasSaml2Config opts = 
+    ( SpPrivateKey opts
+    )
+
+class SpPrivateKey opts where
+    -- | `spPrivateKey` @config@ retrieves the SP's private key, if encrypted
+    -- assertions are used.
+    spPrivateKey :: SAML2Config opts -> Maybe PrivateKey
+
+instance SpPrivateKey (PlainTextAssertions ': os) where
+    spPrivateKey _ = Nothing
+
+instance SpPrivateKey '[] where
+    spPrivateKey cfg = Just (saml2PrivateKey cfg)
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR will add support for unencrypted assertions (#5). 

In particular, we ensure that the configuration's type reflects this: the `SAML2Config` type is now parameterised over a list of type-level flags reflecting the security configuration. The library defaults are represented simply by an empty type-level list `'[]` while settings which change the defaults are added to the list so that it is easy to spot if there are potential security issues.

For unencrypted assertions, we have a new smart constructor `saml2PlainTextConfig` which is like `saml2Config`, but does not require a private key for the service provider. The resulting type of configuration is `SAML2Config '[PlainTextAssertions]`.