### PR TITLE
Fixes for Keycloak

### DIFF
--- a/src/Network/Wai/SAML2/Signature.hs
+++ b/src/Network/Wai/SAML2/Signature.hs
@@ -83,9 +83,9 @@ instance FromXML Reference where
         -- the reference starts with a #, drop it
         let uri = T.drop 1 $ T.concat $ attribute "URI" cursor
 
-        digestMethod <- oneOrFail "DigestMethod is required" $
+        digestMethod <- oneOrFail "DigestMethod is required" (
             cursor $/ element (dsName "DigestMethod") 
-            >=> parseXML
+            ) >>= parseXML
 
         let digestValue = encodeUtf8 $ T.concat $
                 cursor $/ element (dsName "DigestValue") &/ content
@@ -113,21 +113,21 @@ instance FromXML SignedInfo where
     parseXML cursor = do 
         canonicalisationMethod <- 
                 oneOrFail "CanonicalizationMethod is required"
-              $ cursor 
+              ( cursor
              $/ element (dsName "CanonicalizationMethod") 
-            >=> parseXML
+              ) >>= parseXML
 
         signatureMethod <- 
                 oneOrFail "SignatureMethod is required" 
-              $ cursor 
+              ( cursor
              $/ element (dsName "SignatureMethod")
-            >=> parseXML
+            ) >>= parseXML
 
         reference <- 
                 oneOrFail "Reference is required" 
-              $ cursor 
+              ( cursor
              $/ element (dsName "Reference")
-            >=> parseXML
+            ) >>= parseXML
 
         pure SignedInfo{
             signedInfoCanonicalisationMethod = canonicalisationMethod,
@@ -145,8 +145,8 @@ data Signature = Signature {
 
 instance FromXML Signature where 
     parseXML cursor = do 
-        info <- oneOrFail "SignedInfo is required" $ 
-            cursor $/ element (dsName "SignedInfo") >=> parseXML
+        info <- oneOrFail "SignedInfo is required" (
+            cursor $/ element (dsName "SignedInfo") ) >>= parseXML
 
         let value = encodeUtf8 $ T.concat $
                 cursor $/ element (dsName "SignatureValue") &/ content

--- a/src/Network/Wai/SAML2/XML/Encrypted.hs
+++ b/src/Network/Wai/SAML2/XML/Encrypted.hs
@@ -72,7 +72,7 @@ data EncryptedKey = EncryptedKey {
     -- | The method used to encrypt the key.
     encryptedKeyMethod :: !EncryptionMethod,
     -- | The key data.
-    encryptedKeyData :: !KeyInfo,
+    encryptedKeyData :: !(Maybe KeyInfo),
     -- | The ciphertext.
     encryptedKeyCipher :: !CipherData
 } deriving (Eq, Show)
@@ -83,9 +83,9 @@ instance FromXML EncryptedKey where
             cursor $/ element (xencName "EncryptionMethod")
                 ) >>= parseXML
 
-        keyData <- oneOrFail "KeyInfo is required" (
-            cursor $/ element (dsName "KeyInfo")
-                ) >>= parseXML
+        keyData <- case cursor $/ element (dsName "KeyInfo") of
+                     [] -> return Nothing
+                     (keyInfo :_) -> Just <$> parseXML keyInfo
 
         cipher <- oneOrFail "CipherData is required" (
             cursor $/ element (xencName "CipherData")

--- a/src/Network/Wai/SAML2/XML/Encrypted.hs
+++ b/src/Network/Wai/SAML2/XML/Encrypted.hs
@@ -12,7 +12,7 @@ module Network.Wai.SAML2.XML.Encrypted (
     EncryptionMethod(..),
     EncryptedKey(..),
     EncryptedAssertion(..)
-) where 
+) where
 
 --------------------------------------------------------------------------------
 
@@ -32,11 +32,11 @@ data CipherData = CipherData {
     cipherValue :: !BS.ByteString
 } deriving (Eq, Show)
 
-instance FromXML CipherData where 
+instance FromXML CipherData where
     parseXML cursor = pure CipherData{
         cipherValue = encodeUtf8
-                    $ T.concat 
-                    $ cursor 
+                    $ T.concat
+                    $ cursor
                     $/ element (xencName "CipherValue")
                     &/ content
     }
@@ -51,15 +51,15 @@ data EncryptionMethod = EncryptionMethod {
     encryptionMethodDigestAlgorithm :: !(Maybe T.Text)
 } deriving (Eq, Show)
 
-instance FromXML EncryptionMethod where 
+instance FromXML EncryptionMethod where
     parseXML cursor = pure EncryptionMethod{
-        encryptionMethodAlgorithm = 
+        encryptionMethodAlgorithm =
             T.concat $ attribute "Algorithm" cursor,
-        encryptionMethodDigestAlgorithm = 
-            toMaybeText $ cursor 
-                        $/ element (dsName "DigestMethod") 
+        encryptionMethodDigestAlgorithm =
+            toMaybeText $ cursor
+                        $/ element (dsName "DigestMethod")
                        >=> attribute "Algorithm"
-    } 
+    }
 
 --------------------------------------------------------------------------------
 
@@ -77,20 +77,20 @@ data EncryptedKey = EncryptedKey {
     encryptedKeyCipher :: !CipherData
 } deriving (Eq, Show)
 
-instance FromXML EncryptedKey where 
+instance FromXML EncryptedKey where
     parseXML cursor =  do
-        method <- oneOrFail "EncryptionMethod is required" $
-            cursor $/ element (xencName "EncryptionMethod") 
-                >=> parseXML
+        method <- oneOrFail "EncryptionMethod is required" (
+            cursor $/ element (xencName "EncryptionMethod")
+                ) >>= parseXML
 
-        keyData <- oneOrFail "KeyInfo is required" $
-            cursor $/ element (dsName "KeyInfo") 
-                >=> parseXML
+        keyData <- oneOrFail "KeyInfo is required" (
+            cursor $/ element (dsName "KeyInfo")
+                ) >>= parseXML
 
-        cipher <- oneOrFail "CipherData is required" $
+        cipher <- oneOrFail "CipherData is required" (
             cursor $/ element (xencName "CipherData")
-                >=> parseXML
-        
+                ) >>= parseXML
+
         pure EncryptedKey{
             encryptedKeyId = T.concat $ attribute "Id" cursor,
             encryptedKeyRecipient = T.concat $ attribute "Recipient" cursor,
@@ -111,23 +111,23 @@ data EncryptedAssertion = EncryptedAssertion {
     encryptedAssertionCipher :: !CipherData
 } deriving (Eq, Show)
 
-instance FromXML EncryptedAssertion where 
+instance FromXML EncryptedAssertion where
     parseXML cursor = do
-        algorithm <- oneOrFail "Algorithm is required" 
-                 $   cursor 
+        algorithm <- oneOrFail "Algorithm is required"
+                 (   cursor
                  $/  element (xencName "EncryptionMethod")
-                 >=> parseXML  
+                 ) >>= parseXML
 
-        keyInfo <- oneOrFail "KeyInfo is required" 
-               $   cursor 
-               $/  element (dsName "KeyInfo") 
-               &/  element (xencName "EncryptedKey") 
-               >=> parseXML
+        keyInfo <- oneOrFail "KeyInfo is required"
+               (   cursor
+               $/  element (dsName "KeyInfo")
+               &/  element (xencName "EncryptedKey")
+               ) >>= parseXML
 
-        cipher <- oneOrFail "CipherData is required" 
-               $  cursor 
+        cipher <- oneOrFail "CipherData is required"
+               (  cursor
               $/  element (xencName "CipherData")
-              >=> parseXML 
+              ) >>= parseXML
 
         pure EncryptedAssertion{
             encryptedAssertionAlgorithm = algorithm,


### PR DESCRIPTION
I'm tyring to use your library with keycloak, and made a few changes to accommodate that use case:

* I removed `encryptedKeyData` from [EncryptedKey](https://github.com/mbg/wai-saml2/blob/9d465ce2eddfd682eff3d641b627e48c515d7e57/src/Network/Wai/SAML2/XML/Encrypted.hs#L75). It's not used anywhere and prevented the assertion from being parsed.
* The parsing code had a subtle bug: 

Take for example (from [here](https://github.com/mbg/wai-saml2/blob/9d465ce2eddfd682eff3d641b627e48c515d7e57/src/Network/Wai/SAML2/Signature.hs#L114-L118)): 

```haskell
                oneOrFail "CanonicalizationMethod is required"
              $ cursor 
             $/ element (dsName "CanonicalizationMethod") 
            >=> parseXML
```
This parses as 

```haskell
                oneOrFail "CanonicalizationMethod is required"
              ( cursor 
                 $/ element (dsName "CanonicalizationMethod") 
                 >=> parseXML)
```

Note how the `oneOrFail` applies the whole expression including the `>=> parseXML`.
The problem arises when `parseXML` throws an error. The correct behaviour is that the error gets thrown according to the MonadFail instance of the outer expression. However, because `oneOrFail` expects a list, parseXML uses the `MonadFail` instance of list, which just discards the error and returns an empty list. `oneOrFail` then throws its own error. 
The result is that the error that `parseXML` threw is replaced, making debugging a lot harder.

I replaced it with the following code, which propagates errors correctly:
```haskell
        canonicalisationMethod <- 
                oneOrFail "CanonicalizationMethod is required"
              ( cursor
             $/ element (dsName "CanonicalizationMethod") 
              ) >>= parseXML
```