### PR TITLE
Add subjectNameId to Subject

### DIFF
--- a/src/Network/Wai/SAML2/Assertion.hs
+++ b/src/Network/Wai/SAML2/Assertion.hs
@@ -82,7 +82,9 @@ instance FromXML SubjectConfirmation where
 -- | The subject of the assertion.
 data Subject = Subject {
     -- | The list of subject confirmation elements, if any.
-    subjectConfirmations :: ![SubjectConfirmation]
+    subjectConfirmations :: ![SubjectConfirmation],
+    -- | The name identifier of subject.
+    subjectNameId :: !T.Text
 } deriving (Eq, Show)
 
 instance FromXML Subject where 
@@ -91,7 +93,8 @@ instance FromXML Subject where
             cursor $/ element (saml2Name "SubjectConfirmation") &| parseXML
 
         pure Subject{
-            subjectConfirmations = confirmations
+            subjectConfirmations = confirmations,
+            subjectNameId        = T.concat $ cursor $/ element (saml2Name "NameID") &/ content
         }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I added `subjectNameId`, so that SP can identify users by identifier.