### PR TITLE
Improve CI workflow to be more robust

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         resolver:
           - stack-lts-19

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,10 +47,10 @@ jobs:
             ${{ runner.os }}-${{ matrix.resolver }}-
 
       - name: Install dependencies
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --only-dependencies --fast
+        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --only-dependencies --fast
 
       - name: Build
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast
+        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --no-run-tests --fast
 
       - name: Test
         run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -45,7 +45,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-
             ${{ runner.os }}-${{ matrix.resolver }}-
-            ${{ runner.os }}-
 
       - name: Install dependencies
         run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --only-dependencies --fast


### PR DESCRIPTION
- Do not fail matrix builds automatically if one of them fails.
- Do not use `runner.os` as the sole restore key for the cache to avoid mixing caches between different resolvers.