### PR TITLE
Shorten SAML Request ID and make it hexadecimal, then prepend "id"

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ dependencies:
 - base >= 4.8 && < 5
 - text < 2
 - bytestring >= 0.9 && < 0.12
+- base16-bytestring >= 0.1 && < 1.1
 - base64-bytestring >= 0.1 && < 2
 - containers >= 0.6 && <0.7
 - data-default-class < 1

--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -32,6 +32,7 @@ import Network.Wai.SAML2.XML
 import Text.XML
 
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as Map
@@ -64,7 +65,9 @@ issueAuthnRequest
     -> IO AuthnRequest
 issueAuthnRequest authnRequestIssuer = do
     authnRequestTimestamp <- getCurrentTime
-    authnRequestID <- T.decodeUtf8 . Base64.encode <$> getRandomBytes 64
+    -- Azure AD does not accept an id starting with a number
+    -- https://learn.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-saml-protocol
+    authnRequestID <- ("id" <>) . T.decodeUtf8 . Base16.encode <$> getRandomBytes 16
     pure AuthnRequest{
         authnRequestAllowCreate = True
     ,   authnRequestNameIDFormat =

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -56,6 +56,7 @@ library
   ghc-options: -W
   build-depends:
       base >=4.8 && <5
+    , base16-bytestring >=0.1 && <1.1
     , base64-bytestring >=0.1 && <2
     , bytestring >=0.9 && <0.12
     , c14n >=0.1.0.1 && <1
@@ -89,6 +90,7 @@ test-suite parser
   ghc-options: -Wall -Wcompat
   build-depends:
       base
+    , base16-bytestring >=0.1 && <1.1
     , base64-bytestring >=0.1 && <2
     , bytestring
     , c14n >=0.1.0.1 && <1


### PR DESCRIPTION
Apparently AzureAD has some picky undocumented restriction about the request ID. I reported this to https://github.com/MicrosoftDocs/SupportArticles-docs/issues/763 too.

I confirmed that AzureAD accepts the new format
