### PR TITLE
Build documentation in CI and upload as artifact

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,10 +47,19 @@ jobs:
             ${{ runner.os }}-${{ matrix.resolver }}-
 
       - name: Install dependencies
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --only-dependencies --fast
+        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --haddock --only-dependencies --fast
 
       - name: Build
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --no-run-tests --fast
+        run: |
+          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast \
+            --test --no-run-tests \
+            --haddock --haddock-arguments='-odocs'
+
+      - name: Upload documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs-${{ matrix.resolver }}
+          path: docs/
 
       - name: Test
         run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+
+docs/


### PR DESCRIPTION
Modifies the `haskell` CI to build the Haddock documentation and upload the generated files as a build artifact.