### PR TITLE
Update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Split `validateResponse` into `decodeResponse` and `validateSAMLResponse` ([#31](https://github.com/mbg/wai-saml2/pull/31) by [@fumieval](https://github.com/fumieval))
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 * Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
+* Add new module `Network.Wai.SAML2.Request` with AuthnRequest generation for SP-initiated login flow
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Split `validateResponse` into `decodeResponse` and `validateSAMLResponse` ([#31](https://github.com/mbg/wai-saml2/pull/31) by [@fumieval](https://github.com/fumieval))
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 * Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
-* Add new module `Network.Wai.SAML2.Request` with AuthnRequest generation for SP-initiated login flow
+* Add new module `Network.Wai.SAML2.Request` with `AuthnRequest` generation for SP-initiated login flow ([#19](https://github.com/mbg/wai-saml2/pull/19) by [@fumieval](https://github.com/fumieval))
 
 ## 0.3
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@
 ![stackage-nightly](https://github.com/mbg/wai-saml2/workflows/stackage-nightly/badge.svg)
 [![Hackage](https://img.shields.io/hackage/v/wai-saml2)](https://hackage.haskell.org/package/wai-saml2)
 
-A Haskell library which implements SAML2 assertion validation as WAI middleware. This can be used by a Haskell web application (the service provider, SP) to perform identity provider (IdP) initiated authentication, i.e. SAML2-based authentication where the authentication begins at the IdP-end, the IdP authenticates the user, and then gets the user to submit a SAML2 assertion back to the SP (known as "unsolicited SSO" within e.g. [the Shibboleth project](https://wiki.shibboleth.net/confluence/display/IDP30/UnsolicitedSSOConfiguration#UnsolicitedSSOConfiguration-SAML2.0)). 
+A Haskell library which implements SAML2 assertion validation as WAI middleware. This can be used by a Haskell web application (the service provider, SP) to perform identity provider (IdP) initiated authentication, i.e. SAML2-based authentication where the authentication begins at the IdP-end, the IdP authenticates the user, and then gets the user to submit a SAML2 assertion back to the SP (known as "unsolicited SSO" within e.g. [the Shibboleth project](https://wiki.shibboleth.net/confluence/display/IDP30/UnsolicitedSSOConfiguration#UnsolicitedSSOConfiguration-SAML2.0)).
 
 ## Completeness
 
 There are currently a number of limitations to this library:
 
-* As mentioned above, while the library implements IdP-initiated authentication, it does not yet implement SP-initiated authentication (where the SP submits a login request to the IdP).
+* The library implements IdP-initiated authentication and has some support for SP-initiated authentication (See Network.Wai.SAML2.Request)
 
 * The library does not currently support the full SAML2 specification and makes certain assumptions about what the IdP's responses contain. It will most likely fail with any IdPs which do not send responses in the same format. If you wish to use this library and encounter problems with your IdP, please open an issue or a pull request which implements support accordingly.
-  * The library expects that SAML _assertions_ will be encrypted and will decrypt these. There is currently no support for plain-text assertions.
-  
+
 ## Security
 
 The library is estimated to be sufficiently robust for use in a production environment. If you wish to implement this middleware, please note the following:
@@ -26,20 +25,20 @@ The library is estimated to be sufficiently robust for use in a production envir
 
 ## Usage
 
-### Preliminaries 
+### Preliminaries
 
 You need to have registered your service provider with the identity provider. You need to have access to the IdP's metadata, which will contain the public key used for signature validation.
 
 ### Configuration
 
-The `saml2Config` function may be used to construct `SAML2Config` values. It expects at least the SP's private key and the IdP's public key as arguments, but you should almost certainly customise the configuration further. The private and public keys can be loaded with functions from the `Data.X509` and `Data.X509.File` modules (from the `x509` and `x509-store` packages, respectively):
+The `saml2Config` function may be used to construct `SAML2Config` values. It expects at least the SP's private key and the IdP's public key as arguments (even when mandatory encryption is disabled) but you should almost certainly customise the configuration further. The private and public keys can be loaded with functions from the `Data.X509` and `Data.X509.File` modules (from the `x509` and `x509-store` packages, respectively):
 
 ```haskell
 (saml2Config spPrivateKey idpPublicKey){
     saml2AssertionPath = "/sso/assert",
     saml2ExpectedIssuer = Just "https://idp.sp.com/saml2",
     saml2ExpectedDestination = Just "https://example.com/sso/assert",
-} 
+}
 ```
 
 The configuration options are documented in the Haddock documentation for the `Network.Wai.SAML2.Config` module.
@@ -54,27 +53,27 @@ saml2Callback cfg callback mainApp
            -- a POST request was made to the assertion endpoint, but
            -- something went wrong, details of which are provided by
            -- the error: this should probably be logged as it may
-           -- indicate that an attack was attempted against the 
+           -- indicate that an attack was attempted against the
            -- endpoint, but you *must* not show the error
            -- to the client as it would severely compromise
            -- system security
-           -- 
+           --
            -- you may also want to return e.g. a HTTP 400 or 401 status
-       callback (Right result) app req sendResponse = do   
+       callback (Right result) app req sendResponse = do
            -- a POST request was made to the assertion endpoint and the
-           -- SAML2 response was successfully validated:        
-           -- you *must* check that you have not encountered the 
+           -- SAML2 response was successfully validated:
+           -- you *must* check that you have not encountered the
            -- assertion ID before; we assume that there is a
            -- computation tryRetrieveAssertion which looks up
            -- assertions by ID in e.g. a database
            result <- tryRetrieveAssertion (assertionId (assertion result))
-           
-           case result of 
+
+           case result of
                Just something -> -- a replay attack has occurred
                Nothing -> do
                    -- store the assertion id somewhere
                    storeAssertion (assertionId (assertion result))
-                   
+
                    -- the assertion is valid and you can now e.g.
                    -- retrieve user data from your database
                    -- before proceeding with the request by e.g.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Haskell library which implements SAML2 assertion validation as WAI middleware.
 
 There are currently a number of limitations to this library:
 
-* The library implements IdP-initiated authentication and has some support for SP-initiated authentication (See Network.Wai.SAML2.Request)
+* The library implements IdP-initiated authentication and has some support for SP-initiated authentication (See the documentation for the `Network.Wai.SAML2.Request` module)
 
 * The library does not currently support the full SAML2 specification and makes certain assumptions about what the IdP's responses contain. It will most likely fail with any IdPs which do not send responses in the same format. If you wish to use this library and encounter problems with your IdP, please open an issue or a pull request which implements support accordingly.
 


### PR DESCRIPTION
I had implemented (a less complete) version of AuthnRequests in another project and was about to work on merging it here, so I'm pleased to see that the work is already done :sweat_smile: 

this PR adds the references/notes I used took my implementation, since I found that they kept coming in handy. I hope they can be useful here as well.

* I have also added a mention of `Network.Wai.SAML2.Request` in the changelog and updated the README