### PR TITLE
Use DEFLATE compression when rendering AuthnRequest

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
 - time >= 1.9 && < 2
 - mtl >= 2.2.1 && < 3
 - c14n >= 0.1.0.1 && < 1
+- zlib >= 0.6.0.0 && < 0.7
 
 library:
     source-dirs: src

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -77,6 +77,7 @@ library
     , x509 <2
     , x509-store <2
     , xml-conduit <2
+    , zlib >=0.6.0.0 && <0.7
   default-language: Haskell2010
 
 test-suite parser
@@ -116,4 +117,5 @@ test-suite parser
     , x509 <2
     , x509-store <2
     , xml-conduit
+    , zlib >=0.6.0.0 && <0.7
   default-language: Haskell2010


### PR DESCRIPTION
This PR changes AuthnRequest rendering to compress using DEFLATE before Base64-encoding. 

* Required by SAML HTTP redirect binding if no other encoding is specified
* Uncompressed request is in fact rejected by Keycloak with `Invalid Request` 
* The use of HTTP redirect binding is implied by the the comment:
> which should be used as a query parameter named @SAMLRequest@

This change might break @fumieval's use case, if so we should probably make it configurable, but this is the explicitly mentioned standard behaviour

Reference: 

> A query string parameter named SAMLEncoding is reserved to identify the
encoding mechanism used. If this parameter is omitted, then the value is assumed to be urn:oasis:names:tc:SAML:2.0:bindings:URL-Encoding:DEFLATE

https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf#page=17
