### PR TITLE
Split validateResponse into decodeResponse and validateSAMLResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added `decodeResponse` and `validateSAMLResponse`
+* Split `validateResponse` into `decodeResponse` and `validateSAMLResponse` ([#31](https://github.com/mbg/wai-saml2/pull/31) by [@fumieval](https://github.com/fumieval))
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 
 ## 0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added `decodeResponse` and `validateSAMLResponse`
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 
 ## 0.3

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -53,13 +53,13 @@ validateResponse cfg responseData = runExceptT $ do
     -- get the current time
     now <- liftIO $ getCurrentTime
 
-    (responseXmlDoc, samlResponse) <- ExceptT $ decodeResponse responseData
-    ExceptT $ validateSAMLResponse cfg responseXmlDoc samlResponse now
+    (responseXmlDoc, samlResponse) <- decodeResponse responseData
+    validateSAMLResponse cfg responseXmlDoc samlResponse now
 
 -- | 'decodeResponse' @responseData@ decodes a SAML2 response contained
 -- in Base64-encoded @responseData@.
-decodeResponse :: BS.ByteString -> IO (Either SAML2Error (XML.Document, Response))
-decodeResponse responseData = runExceptT $ do
+decodeResponse :: BS.ByteString -> ExceptT SAML2Error IO (XML.Document, Response)
+decodeResponse responseData = do
     -- the response data is Base64-encoded; decode it
     let resXmlDocData = BS.decodeLenient responseData
 
@@ -83,8 +83,8 @@ validateSAMLResponse :: SAML2Config
                      -> XML.Document
                      -> Response
                      -> UTCTime
-                     -> IO (Either SAML2Error Assertion)
-validateSAMLResponse cfg responseXmlDoc samlResponse now = runExceptT $ do
+                     -> ExceptT SAML2Error IO Assertion
+validateSAMLResponse cfg responseXmlDoc samlResponse now = do
 
     -- check that the response indicates success
     case responseStatusCode samlResponse of

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -8,6 +8,8 @@
 -- | Functions to process and validate SAML2 respones.
 module Network.Wai.SAML2.Validation (
     validateResponse,
+    decodeResponse,
+    validateSAMLResponse,
     ansiX923
 ) where
 
@@ -51,6 +53,13 @@ validateResponse cfg responseData = runExceptT $ do
     -- get the current time
     now <- liftIO $ getCurrentTime
 
+    (responseXmlDoc, samlResponse) <- ExceptT $ decodeResponse responseData
+    ExceptT $ validateSAMLResponse cfg responseXmlDoc samlResponse now
+
+-- | 'decodeResponse' @responseData@ decodes a SAML2 response contained
+-- in Base64-encoded @responseData@.
+decodeResponse :: BS.ByteString -> IO (Either SAML2Error (XML.Document, Response))
+decodeResponse responseData = runExceptT $ do
     -- the response data is Base64-encoded; decode it
     let resXmlDocData = BS.decodeLenient responseData
 
@@ -64,9 +73,18 @@ validateResponse cfg responseData = runExceptT $ do
     resParseResult <- liftIO $ try $
         parseXML (XML.fromDocument responseXmlDoc)
 
-    samlResponse <- case resParseResult of
+    case resParseResult of
         Left err -> throwError $ InvalidResponse err
-        Right samlResponse -> pure samlResponse
+        Right samlResponse -> pure (responseXmlDoc, samlResponse)
+
+-- | 'validateSAMLResponse' @cfg doc response timestamp@ validates a decoded SAML2
+-- response using the given @timestamp@.
+validateSAMLResponse :: SAML2Config
+                     -> XML.Document
+                     -> Response
+                     -> UTCTime
+                     -> IO (Either SAML2Error Assertion)
+validateSAMLResponse cfg responseXmlDoc samlResponse now = runExceptT $ do
 
     -- check that the response indicates success
     case responseStatusCode samlResponse of


### PR DESCRIPTION
**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [ ] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.

These are particularly useful when an application wants to peek the contents of `Response` in order to determine which certificate to verify with in multi-tenant usecase. They are helpful for debugging and testing too.
