### PR TITLE
Return response' "InResponseTo" field from validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
-* Added new field `inResponseTo` to `Result` type
+* Added new field `response` to `Result` ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
+* Added new field `inResponseTo` to `Result` type
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
-* Added new field `response` to `Result` ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
+* Added new field `response` to `Result` which contains the full, decoded SAML response ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
 
 ## 0.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,6 @@ extra-source-files:
 
 default-extensions:
 - OverloadedStrings
-- MultiWayIf
 - RecordWildCards
 - FlexibleInstances
 

--- a/src/Network/Wai/SAML2.hs
+++ b/src/Network/Wai/SAML2.hs
@@ -121,10 +121,11 @@ saml2Callback cfg callback app req sendResponse = do
                     let rs = lookup "RelayState" body
                     result <- validateResponse cfg val <&>
                                   fmap (\(assertion, response) ->
-                                          Result
-                                          { assertion = assertion,
-                                            relayState = rs,
-                                            response = response})
+                                            Result{
+                                                assertion = assertion,
+                                                relayState = rs,
+                                                response = response
+                                            })
 
                     -- call the callback
                     callback result app req sendResponse
@@ -217,8 +218,7 @@ data Result = Result {
     relayState :: !(Maybe BS.ByteString),
     -- | The assertion obtained from the response that has been validated.
     assertion :: !Assertion,
-    -- | The ID of the request this result corresponds to to, if any. You
-    -- should check that it matches a request you generated
+    -- | The full response obtained from the IdP.
     --
     -- @since 0.4
     response :: !SAML2.Response

--- a/src/Network/Wai/SAML2.hs
+++ b/src/Network/Wai/SAML2.hs
@@ -43,6 +43,7 @@ import Network.Wai.SAML2.Config
 import Network.Wai.SAML2.Validation
 import Network.Wai.SAML2.Assertion
 import Network.Wai.SAML2.Error
+import qualified Network.Wai.SAML2.Response as SAML2
 
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -121,11 +122,11 @@ saml2Callback cfg callback app req sendResponse = do
                     let rs = lookup "RelayState" body
                     let r = case result of
                               Left e -> Left e
-                              Right (assertion, inResponseTo) ->
+                              Right (assertion, response) ->
                                 Right Result
                                        { assertion = assertion,
                                          relayState = rs,
-                                         inResponseTo = inResponseTo}
+                                         response = response}
 
                     -- call the callback
                     callback r app req sendResponse
@@ -222,7 +223,7 @@ data Result = Result {
     -- should check that it matches a request you generated
     --
     -- @since 0.4
-    inResponseTo :: !(Maybe T.Text)
+    response :: !SAML2.Response
 } deriving (Eq, Show)
 
 --------------------------------------------------------------------------------

--- a/src/Network/Wai/SAML2.hs
+++ b/src/Network/Wai/SAML2.hs
@@ -35,7 +35,6 @@ module Network.Wai.SAML2 (
 import qualified Data.ByteString as BS
 import Data.Functor ((<&>))
 import Data.Maybe (fromMaybe)
-import qualified Data.Text as T
 import qualified Data.Vault.Lazy as V
 
 import Network.Wai

--- a/src/Network/Wai/SAML2/Assertion.hs
+++ b/src/Network/Wai/SAML2/Assertion.hs
@@ -165,6 +165,8 @@ instance FromXML Conditions where
 --------------------------------------------------------------------------------
 
 -- | SAML2 authentication statements.
+
+-- Reference [AuthnStatement]
 data AuthnStatement = AuthnStatement {
     -- | The timestamp when the assertion was issued.
     authnStatementInstant :: !UTCTime,
@@ -270,3 +272,7 @@ instance FromXML Assertion where
         }
 
 --------------------------------------------------------------------------------
+
+-- Reference [AuthnStatement]
+--   Source: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=26
+--   Section: 2.7.2 Element <AuthnStatement>

--- a/src/Network/Wai/SAML2/Response.hs
+++ b/src/Network/Wai/SAML2/Response.hs
@@ -35,9 +35,15 @@ import Network.Wai.SAML2.Signature
 --------------------------------------------------------------------------------
 
 -- | Represents SAML2 responses.
+
+-- Reference [StatusResponseType]
 data Response = Response {
     -- | The intended destination of this response.
     responseDestination :: !T.Text,
+    -- | The ID of the request this responds corresponds to, if any
+    --
+    -- @since 0.4
+    responseInResponseTo :: !(Maybe T.Text),
     -- | The unique ID of the response.
     responseId :: !T.Text,
     -- | The timestamp when the response was issued.
@@ -57,6 +63,7 @@ data Response = Response {
 } deriving (Eq, Show)
 
 instance FromXML Response where
+    -- Reference [StatusResponseType]
     parseXML cursor = do
         issueInstant <- parseUTCTime
                       $ T.concat
@@ -82,6 +89,7 @@ instance FromXML Response where
         pure Response{
             responseDestination = T.concat $ attribute "Destination" cursor,
             responseId = T.concat $ attribute "ID" cursor,
+            responseInResponseTo = listToMaybe $ attribute "InResponseTo" cursor,
             responseIssueInstant = issueInstant,
             responseVersion = T.concat $ attribute "Version" cursor,
             responseIssuer = T.concat $
@@ -122,3 +130,7 @@ extractSignedInfo cursor = do
     pure signedInfo
 
 --------------------------------------------------------------------------------
+
+-- Reference [StatusResponseType]
+--   Source: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=38
+--   Section: 3.2.2 Complex Type StatusResponseType

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -31,7 +31,6 @@ import qualified Data.ByteString.Base64 as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Default.Class
 import Data.Time
-import qualified Data.Text as T
 
 import Network.Wai.SAML2.XML.Encrypted
 import Network.Wai.SAML2.Config

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -213,7 +213,7 @@ validateSAMLResponse cfg responseXmlDoc samlResponse now = do
     then throwError NotValid
     else pure ()
 
-    -- all checks out, return the assertion and InResponseTo field
+    -- all checks out, return the assertion
     pure assertion
 
 -- | `decryptAssertion` @key encryptedAssertion@ decrypts the AES key in

--- a/tests/data/google.xml.expected
+++ b/tests/data/google.xml.expected
@@ -1,6 +1,9 @@
 Response
   { responseDestination =
       "https://herp.loopback.ja-sore.de/auth/page/saml2/login"
+  , responseInResponseTo =
+      Just
+        "1WKzv/yHPExwtkwhgObMyn/GVaTIIZAc+DqEfqe1YuYyjmw4YitoSHGhI/xufWqEHUhrSPtrzzyi5938vebpVg=="
   , responseId = "_b9917f3478ff3f776cb351547379d0bc"
   , responseIssueInstant = 2022-09-20 10:30:41.151 UTC
   , responseVersion = "2.0"

--- a/tests/data/keycloak.xml.expected
+++ b/tests/data/keycloak.xml.expected
@@ -1,6 +1,7 @@
 Response
   { responseDestination =
       "http://loopback.ja-sore.de:3000/auth/page/saml2/login"
+  , responseInResponseTo = Nothing
   , responseId = "ID_5b1d000b-3a5e-4dfe-aa4e-b7bf1e3efbfd"
   , responseIssueInstant = 2022-08-01 00:32:49.365 UTC
   , responseVersion = "2.0"

--- a/tests/data/okta.xml.expected
+++ b/tests/data/okta.xml.expected
@@ -1,6 +1,7 @@
 Response
   { responseDestination =
       "http://loopback.ja-sore.de:3000/auth/page/saml2/login"
+  , responseInResponseTo = Nothing
   , responseId = "id36905492230634463108368061"
   , responseIssueInstant = 2022-07-28 13:53:54.059 UTC
   , responseVersion = "2.0"

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -54,7 +54,6 @@ library
       src
   default-extensions:
       OverloadedStrings
-      MultiWayIf
       RecordWildCards
       FlexibleInstances
   ghc-options: -W
@@ -89,7 +88,6 @@ test-suite parser
       tests
   default-extensions:
       OverloadedStrings
-      MultiWayIf
       RecordWildCards
       FlexibleInstances
   ghc-options: -Wall -Wcompat


### PR DESCRIPTION
This PR adds support for `InResponseTo` in `Response` elements

* Adds field `inResponseTo` to `Result` type
* Changes the type of the `validateResponse` function to return it together with the validated assertion
* Should (or rather, `MUST`) be matched to request IDs, also depending on if unsolicited assertions are allowed.

According to saml-core [1]:

> InResponseTo [Optional]
A reference to the identifier of the request to which the response corresponds, if any. If the response
is not generated in response to a request, or if the ID attribute value of a request cannot be
determined (for example, the request is malformed), then this attribute MUST NOT be present.
Otherwise, it MUST be present and its value MUST match the value of the corresponding request's
ID attribute.

Also compare this stack exchange post [2] which argues that this value should be validated

I don't think this validation has to happen within this library, but it should be returned so that callers of the library can implement it themselves, similar to how checks for duplicate `assertionId` are left as an exercise to the reader :sweat_smile: 


* [1] https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=38
* [2] https://security.stackexchange.com/questions/42354/do-i-have-to-validate-saml2-inresponseto


**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] The changelog has been updated.
