### PR TITLE
Validation of audience restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
 * Added new field `response` to `Result` which contains the full, decoded SAML response ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
-* Validate audience restrictions  (https://github.com/mbg/wai-saml2/issues/34)
+* Validate audience restrictions  ([#35](https://github.com/mbg/wai-saml2/pull/35) by [@Philonous](https://github.com/Philonous))
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
 * Added new field `response` to `Result` which contains the full, decoded SAML response ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
+* Validate audience restrictions  (https://github.com/mbg/wai-saml2/issues/34)
 
 ## 0.3
 

--- a/src/Network/Wai/SAML2/Config.hs
+++ b/src/Network/Wai/SAML2/Config.hs
@@ -37,6 +37,10 @@ data SAML2Config = SAML2Config {
     saml2ExpectedIssuer :: !(Maybe T.Text),
     -- | The URL we expect the SAML2 response to contain as destination.
     saml2ExpectedDestination :: !(Maybe T.Text),
+    -- | The audiences we are a member of. An assertions is only valid if we are
+    -- a member of at least one of its audiences. Leaving this empty disables
+    -- the check
+    saml2Audiences :: ![T.Text],
     -- | A value indicating whether to disable time validity checks. This
     -- should not be set to 'True' in a production environment, but may
     -- be useful for testing purposes.
@@ -69,6 +73,7 @@ saml2ConfigNoEncryption pubKey = SAML2Config{
     saml2PublicKey = pubKey,
     saml2ExpectedIssuer = Nothing,
     saml2ExpectedDestination = Nothing,
+    saml2Audiences = [],
     saml2DisableTimeValidation = False,
     saml2RequireEncryptedAssertion = False
 }

--- a/src/Network/Wai/SAML2/Config.hs
+++ b/src/Network/Wai/SAML2/Config.hs
@@ -40,6 +40,8 @@ data SAML2Config = SAML2Config {
     -- | The audiences we are a member of. An assertions is only valid if we are
     -- a member of at least one of its audiences. Leaving this empty disables
     -- the check
+    --
+    -- @since 0.4
     saml2Audiences :: ![T.Text],
     -- | A value indicating whether to disable time validity checks. This
     -- should not be set to 'True' in a production environment, but may

--- a/src/Network/Wai/SAML2/Error.hs
+++ b/src/Network/Wai/SAML2/Error.hs
@@ -55,6 +55,8 @@ data SAML2Error
     | InvalidDigest
     -- | The assertion is not valid.
     | NotValid
+    -- | Audience restrictions don't match our audiences
+    | AudienceMismatch [T.Text]
     -- | A general crypto error occurred.
     | CryptoError CryptoError
     -- | The request made to the configured endpoint is not valid.

--- a/src/Network/Wai/SAML2/Error.hs
+++ b/src/Network/Wai/SAML2/Error.hs
@@ -56,6 +56,8 @@ data SAML2Error
     -- | The assertion is not valid.
     | NotValid
     -- | Audience restrictions don't match our audiences
+    --
+    -- @since 0.4
     | AudienceMismatch [T.Text]
     -- | A general crypto error occurred.
     | CryptoError CryptoError

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -30,7 +30,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Default.Class
-import Data.Foldable (any)
 import Data.Time
 
 import Network.Wai.SAML2.XML.Encrypted

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -222,7 +222,7 @@ validateSAMLResponse cfg responseXmlDoc samlResponse now = do
            forM_ conditionsAudienceRestrictions $
               \(AudienceRestriction audiences) ->
                  unless (any (`elem` ourAudiences) audiences)
-                   $ throwError NotValid
+                   $ throwError (AudienceMismatch audiences)
 
     -- all checks out, return the assertion
     pure assertion

--- a/tests/data/google.xml.expected
+++ b/tests/data/google.xml.expected
@@ -58,7 +58,10 @@ Response
               Conditions
                 { conditionsNotBefore = 2022-09-20 10:25:41.151 UTC
                 , conditionsNotOnOrAfter = 2022-09-20 10:35:41.151 UTC
-                , conditionsAudience = "https://v1.herp.cloud/"
+                , conditionsAudienceRestrictions =
+                    [ AudienceRestriction
+                        { audienceRestrictionAudience = [ "https://v1.herp.cloud/" ] }
+                    ]
                 }
           , assertionAuthnStatement =
               AuthnStatement


### PR DESCRIPTION
This PR implements validation of audience restrictions. It adds a new configuration option `audiences` and a new error type `AudienceMismatch`

Closes #34 

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
