### PR TITLE
Support for GHC 9.4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         resolver:
+          - stack-lts-20
           - stack-lts-19
           - stack-lts-18
           - stack-lts-17.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
+* Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
 
 ## 0.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,7 @@ default-extensions:
 
 dependencies:
 - base >= 4.8 && < 5
-- text < 2
+- text < 2.1
 - bytestring >= 0.9 && < 0.12
 - base16-bytestring >= 0.1 && < 1.1
 - base64-bytestring >= 0.1 && < 2

--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.0
+resolver: lts-19.33

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,0 +1,1 @@
+resolver: lts-20.2

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -69,7 +69,7 @@ library
     , data-default-class <1
     , http-types <1
     , mtl >=2.2.1 && <3
-    , text <2
+    , text <2.1
     , time >=1.9 && <2
     , vault >=0.3 && <1
     , wai >=3.0 && <4
@@ -107,7 +107,7 @@ test-suite parser
     , pretty-show
     , tasty
     , tasty-golden
-    , text <2
+    , text <2.1
     , time >=1.9 && <2
     , vault >=0.3 && <1
     , wai >=3.0 && <4


### PR DESCRIPTION
The Stackage nightly builds are currently broken due to a new release of the `text` package. This raises the upper bound for the `text` package to allow newer version and build with the current nightly snapshots (for GHC 9.4).

**Checklist**

- [x] The changelog has been updated.
