### PR TITLE
make SP private key optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 * Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
 * Add new module `Network.Wai.SAML2.Request` with `AuthnRequest` generation for SP-initiated login flow ([#19](https://github.com/mbg/wai-saml2/pull/19) by [@fumieval](https://github.com/fumieval))
+* Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption ` which takes a `PublicKey` only
 
 ## 0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Exported `NameID` (formerly `NameId`), and renamed `subjectNameId` to `subjectNameID`
 * Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
 * Add new module `Network.Wai.SAML2.Request` with `AuthnRequest` generation for SP-initiated login flow ([#19](https://github.com/mbg/wai-saml2/pull/19) by [@fumieval](https://github.com/fumieval))
-* Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption ` which takes a `PublicKey` only
+* Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
 
 ## 0.3
 

--- a/src/Network/Wai/SAML2/Error.hs
+++ b/src/Network/Wai/SAML2/Error.hs
@@ -61,6 +61,8 @@ data SAML2Error
     | InvalidRequest
     -- | The configuration requires an encrypted assertion, but got a plaintext assertion.
     | EncryptedAssertionRequired
+    -- | The configuration does not support decryption, but got an encrypted assertion.
+    | EncryptedAssertionNotSupported
     deriving Show
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.

This change changes the type of `saml2PrivateKey` field to `Maybe PrivateKey`. It rejects encrypted assertions when this is set to Nothing.

Hopefully this change breaks little code, assuming that `SAML2Config` is constructed via the `saml2Config` function.