### PR TITLE
Request: reduce the precision of IssueInstant to microseconds

### DIFF
--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -32,7 +32,7 @@ module Network.Wai.SAML2.Request (
 import Crypto.Random
 
 import Data.Time.Clock
-import Data.Time.Format
+import Data.Time.Format.ISO8601 (iso8601Show)
 
 import Network.Wai.SAML2.XML
 
@@ -113,8 +113,7 @@ renderXML AuthnRequest{..} =
     ,   documentEpilogue = []
     }
     where
-        timestamp = T.pack $
-            formatTime defaultTimeLocale timeFormat authnRequestTimestamp
+        timestamp = T.pack $ iso8601Show authnRequestTimestamp
         root = Element
             (saml2pName "AuthnRequest")
             (Map.fromList

--- a/src/Network/Wai/SAML2/XML.hs
+++ b/src/Network/Wai/SAML2/XML.hs
@@ -17,7 +17,6 @@ module Network.Wai.SAML2.XML (
     -- * Utility functions
     toMaybeText,
     parseUTCTime,
-    timeFormat,
 
     -- * XML parsing
     FromXML(..),
@@ -28,6 +27,7 @@ module Network.Wai.SAML2.XML (
 
 import qualified Data.Text as T
 import Data.Time
+import Data.Time.Format.ISO8601 (iso8601ParseM)
 
 import Text.XML
 import Text.XML.Cursor
@@ -70,14 +70,9 @@ toMaybeText :: [T.Text] -> Maybe T.Text
 toMaybeText [] = Nothing
 toMaybeText xs = Just $ T.concat xs
 
--- | The time format used by SAML2.
-timeFormat :: String
-timeFormat = "%Y-%m-%dT%H:%M:%S%QZ"
-
 -- | 'parseUTCTime' @text@ parses @text@ into a 'UTCTime' value.
 parseUTCTime :: MonadFail m => T.Text -> m UTCTime
-parseUTCTime value =
-    parseTimeM False defaultTimeLocale timeFormat (T.unpack value)
+parseUTCTime = iso8601ParseM . T.unpack
 
 -- | A class of types which can be parsed from XML.
 class FromXML a where


### PR DESCRIPTION
**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [ ] The changelog has been updated.

It turns out that picosecond resolution in the `IssueInstant` timestamp causes
`XML attribute 'IssueInstant' in the SAML message must be a dateTime.` error on AzureAD. This change fixes the problem by using `iso8601Show` instead, reducing the resolution to microseconds