### PR TITLE
Truncate IssueInstant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Support GHC 9.4 ([#36](https://github.com/mbg/wai-saml2/pull/36) by [@mbg](https://github.com/mbg))
 * Add new module `Network.Wai.SAML2.Request` with `AuthnRequest` generation for SP-initiated login flow ([#19](https://github.com/mbg/wai-saml2/pull/19) by [@fumieval](https://github.com/fumieval))
 * Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
+* Added `showUTCTime` to `Network.Wai.SAML2.XML`
 
 ## 0.3
 

--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -32,7 +32,6 @@ module Network.Wai.SAML2.Request (
 import Crypto.Random
 
 import Data.Time.Clock
-import Data.Time.Format.ISO8601 (iso8601Show)
 
 import Network.Wai.SAML2.XML
 
@@ -113,7 +112,7 @@ renderXML AuthnRequest{..} =
     ,   documentEpilogue = []
     }
     where
-        timestamp = T.pack $ iso8601Show authnRequestTimestamp
+        timestamp = showUTCTime authnRequestTimestamp
         root = Element
             (saml2pName "AuthnRequest")
             (Map.fromList

--- a/src/Network/Wai/SAML2/XML.hs
+++ b/src/Network/Wai/SAML2/XML.hs
@@ -16,6 +16,7 @@ module Network.Wai.SAML2.XML (
 
     -- * Utility functions
     toMaybeText,
+    showUTCTime,
     parseUTCTime,
 
     -- * XML parsing
@@ -69,6 +70,17 @@ mdName name =
 toMaybeText :: [T.Text] -> Maybe T.Text
 toMaybeText [] = Nothing
 toMaybeText xs = Just $ T.concat xs
+
+-- | The time format used by SAML2.
+timeFormat :: String
+timeFormat = "%Y-%m-%dT%H:%M:%S%6QZ"
+
+-- | Display a 'UTCTime' to an ISO8601 timestamp up to microseconds.
+--
+-- @since 0.4.0.0
+--
+showUTCTime :: UTCTime -> T.Text
+showUTCTime = T.pack . formatTime defaultTimeLocale timeFormat
 
 -- | 'parseUTCTime' @text@ parses @text@ into a 'UTCTime' value.
 parseUTCTime :: MonadFail m => T.Text -> m UTCTime


### PR DESCRIPTION
**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [ ] The changelog has been updated.

I drew a conclusion too early when I saw `iso8601Show <$> getCurrentTime` showing 6 decimal places... I realised that it may still show more decimal places if depending on the environment, causing parse errors on AzureAD. 

```
iso8601Show $ UTCTime (toEnum 0) (picosecondsToDiffTime 1)
"1858-11-17T00:00:00.000000000001Z"
```

This change circumvents the problem by truncating the timestamp to 26 characters and appending 'Z'. I wish `time` package had a way to specify the number of decimal places...

```
ghci> length "2023-01-21T10:29:37.649776Z"
27
```
