### PR TITLE
change the type of authnRequestNameIDFormat from Text to NameIDFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new module `Network.Wai.SAML2.Request` with `AuthnRequest` generation for SP-initiated login flow ([#19](https://github.com/mbg/wai-saml2/pull/19) by [@fumieval](https://github.com/fumieval))
 * Changed the `saml2PrivateKey` field to be optional and added `saml2ConfigNoEncryption` which takes a `PublicKey` only
 * Added `showUTCTime` to `Network.Wai.SAML2.XML`
+* Added a new module `Network.Wai.SAML2.NameIDFormat`
 
 ## 0.3
 

--- a/src/Network/Wai/SAML2/NameIDFormat.hs
+++ b/src/Network/Wai/SAML2/NameIDFormat.hs
@@ -11,7 +11,8 @@
 -- of the identifier in an assertion.
 module Network.Wai.SAML2.NameIDFormat (
     NameIDFormat(..),
-    parseNameIDFormat
+    parseNameIDFormat,
+    showNameIDFormat
 ) where
 
 import Data.Text (Text, unpack)
@@ -63,3 +64,20 @@ parseNameIDFormat = \case
     "urn:oasis:names:tc:SAML:2.0:nameid-format:provider" -> pure Provider
     "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" -> pure Transient
     unknown -> fail $ "parseNameIDFormat: unknown format " <> unpack unknown
+
+-- | Display 'NameIDFormat' as a Text.
+--
+-- @since 0.4.0.0
+--
+showNameIDFormat :: NameIDFormat -> Text
+showNameIDFormat = \case
+    KerberosPrincipalName -> "urn:oasis:names:tc:SAML:1.1:nameid-format:Kerberos"
+    WindowsDomainQualifiedName -> "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName"
+    X509SubjectName -> "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName"
+    EmailAddress -> "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+    Unspecified -> "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+    Entity -> "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+    Federated -> "urn:oasis:names:tc:SAML:2.0:nameid-format:federated"
+    Persistent -> "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+    Provider -> "urn:oasis:names:tc:SAML:2.0:nameid-format:provider"
+    Transient -> "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"

--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -33,6 +33,7 @@ import Crypto.Random
 
 import Data.Time.Clock
 
+import Network.Wai.SAML2.NameIDFormat
 import Network.Wai.SAML2.XML
 
 import Text.XML
@@ -63,7 +64,7 @@ data AuthnRequest
         -- | Allow IdP to generate a new identifier
     ,   authnRequestAllowCreate :: !Bool
         -- | The URI reference corresponding to a name identifier format
-    ,   authnRequestNameIDFormat :: !T.Text
+    ,   authnRequestNameIDFormat :: !NameIDFormat
     }
     deriving (Eq, Show)
 
@@ -79,8 +80,7 @@ issueAuthnRequest authnRequestIssuer = do
     authnRequestID <- ("id" <>) . T.decodeUtf8 . Base16.encode <$> getRandomBytes 16
     pure AuthnRequest{
         authnRequestAllowCreate = True
-    ,   authnRequestNameIDFormat =
-            "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+    ,   authnRequestNameIDFormat = Transient
     ,   ..
     }
 
@@ -135,7 +135,7 @@ renderXML AuthnRequest{..} =
             (Map.fromList
                 [ ("allowCreate"
                     , if authnRequestAllowCreate then "true" else "false")
-                , ("Format", authnRequestNameIDFormat)
+                , ("Format", showNameIDFormat authnRequestNameIDFormat)
                 ])
             []
 


### PR DESCRIPTION
**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
