### PR TITLE
Add full support for status codes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.expected]
+insert_final_newline = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added a new module `Network.Wai.SAML2.NameIDFormat`
 * Added new field `response` to `Result` which contains the full, decoded SAML response ([#33](https://github.com/mbg/wai-saml2/pull/33) by [@Philonous](https://github.com/Philonous))
 * Validate audience restrictions  ([#35](https://github.com/mbg/wai-saml2/pull/35) by [@Philonous](https://github.com/Philonous))
+* Handle status codes according to the SAML2 specification ([#42](https://github.com/mbg/wai-saml2/pull/42)) by [@mbg](https://github.com/mbg)
 
 ## 0.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
 - mtl >= 2.2.1 && < 3
 - c14n >= 0.1.0.1 && < 1
 - zlib >= 0.6.0.0 && < 0.7
+- network-uri >= 2.0 && < 3
 
 library:
     source-dirs: src

--- a/src/Network/Wai/SAML2/StatusCode.hs
+++ b/src/Network/Wai/SAML2/StatusCode.hs
@@ -5,39 +5,206 @@
 -- file in the root directory of this source tree.                            --
 --------------------------------------------------------------------------------
 
--- | SAML2 status codes.
+-- | The SAML2 specification distinguishes between the topmost status code,
+-- which is required and must contain a status value from a specific list of
+-- status codes, and subordinate status codes, which are optional and may
+-- contain arbitrary URIs.
 module Network.Wai.SAML2.StatusCode (
-    StatusCode(..)
+    StatusCode(..),
+    StatusCodeValue(..)
 ) where
 
 --------------------------------------------------------------------------------
 
 import Control.Monad
 
+import Data.Maybe
 import qualified Data.Text as T
 
 import Text.XML.Cursor
 
+import Network.URI (URI, parseURI)
 import Network.Wai.SAML2.XML
 
 --------------------------------------------------------------------------------
 
--- | Enumerates SAML2 status codes.
+-- | Represents SAML2 status codes, which are comprised of a status value
+-- and an optional, subordinate status.
 data StatusCode
+    = MkStatusCode {
+        -- | The status code value.
+        statusCodeValue :: !StatusCodeValue,
+        -- | An optional, subordinate status code.
+        statusCodeSubordinate :: !(Maybe StatusCode)
+    }
+    deriving (Eq, Show)
+
+-- | Enumerates SAML2 status code values.
+--
+-- @since 0.4
+data StatusCodeValue
     -- | The response indicates success!
     = Success
+    -- | The request could not be performed due to an error on the part of the
+    -- requester.
+    | Requester
+    -- | The request could not be performed due to an error on the part of the
+    -- SAML responder or SAML authority.
+    | Responder
+    -- | The SAML responder could not process the request because the version
+    -- of the request message was incorrect.
+    | VersionMismatch
+    -- | The responding provider was unable to successfully authenticate the
+    -- principal.
+    | AuthnFailed
+    -- | Unexpected or invalid content was encountered within a
+    -- @\<saml:Attribute\>@ or @\<saml:AttributeValue\>@ element.
+    | InvalidAttrNameOrValue
+    -- | The responding provider cannot or will not support the requested name
+    -- identifier policy.
+    | InvalidNameIDPolicy
+    -- | The specified authentication context requirements cannot be met by the
+    -- responder.
+    | NoAuthnContext
+    -- | Used by an intermediary to indicate that none of the supported
+    -- identity provider @\<Loc\>@ elements in an @\<IDPList\>@ can be resolved
+    -- or that none of the supported identity providers are available.
+    | NoAvailableIDP
+    -- | Indicates the responding provider cannot authenticate the principal
+    -- passively, as has been requested.
+    | NoPassive
+    -- | Used by an intermediary to indicate that none of the identity
+    -- providers in an @\<IDPList\>@ are supported by the intermediary.
+    | NoSupportedIDP
+    -- | Used by a session authority to indicate to a session participant that
+    -- it was not able to propagate logout to all other session participants.
+    | PartialLogout
+    -- | Indicates that a responding provider cannot authenticate the principal
+    -- directly and is not permitted to proxy the request further.
+    | ProxyCountExceeded
+    -- | The SAML responder or SAML authority is able to process the request
+    -- but has chosen not to respond. This status code MAY be used when there
+    -- is concern about the security context of the request message or the
+    -- sequence of request messages received from a particular requester.
+    | RequestDenied
+    -- | The SAML responder or SAML authority does not support the request.
+    | RequestUnsupported
+    -- | The SAML responder cannot process any requests with the protocol
+    --  version specified in the request.
+    | RequestVersionDeprecated
+    -- | The SAML responder cannot process the request because the protocol
+    -- version specified in the request message is a major upgrade from the
+    -- highest protocol version supported by the responder.
+    | RequestVersionTooHigh
+    -- | The SAML responder cannot process the request because the protocol
+    -- version specified in the request message is too low.
+    | RequestVersionTooLow
+    -- | The resource value provided in the request message is invalid or
+    -- unrecognized.
+    | ResourceNotRecognized
+    -- | The response message would contain more elements than the SAML
+    -- responder is able to return.
+    | TooManyResponses
+    -- | An entity that has no knowledge of a particular attribute profile
+    -- has been presented with an attribute drawn from that profile.
+    | UnknownAttrProfile
+    -- | The responding provider does not recognize the principal specified
+    -- or implied by the request.
+    | UnknownPrincipal
+    -- | The SAML responder cannot properly fulfil the request using the
+    -- protocol binding specified in the request.
+    | UnsupportedBinding
+    -- | The SAML2 specification notes that a status code value can be any
+    -- valid URI and that additional subordinate status codes may be
+    -- introduced in the future.
+    | OtherStatus URI
     deriving (Eq, Show)
 
 instance FromXML StatusCode where
-    parseXML cursor =
-        let value = T.concat
-                $   cursor
-                $/  element (saml2pName "Status")
-                &/  element (saml2pName "StatusCode")
-                >=> attribute "Value"
-        in case value of
-            "urn:oasis:names:tc:SAML:2.0:status:Success" -> pure Success
-            _ -> fail "Not a valid status code."
+    parseXML = parseStatusCode True
 
+-- | `parseStatusCode` @isTopLevel cursor@ attempts to parse a @<StatusCode>@
+-- element from the XML @cursor@. The SAML2 specification distinguishes
+-- between the topmost status code, which is required and must contain a
+-- status value from a specific list of status codes, and subordinate status
+-- codes. The @isTopLevel@ value indicates whether we are parsing a top-level
+-- @<StatusCode>@ element or not and therefore controls which status codes
+-- values we accept as valid.
+--
+-- @since 0.4
+parseStatusCode :: MonadFail m => Bool -> Cursor -> m StatusCode
+parseStatusCode isTopLevel cursor = do
+    statusCodeValue <- oneOrFail "Value is a required attribute" $
+        cursor $/
+            element (saml2pName "Status") &/
+            element (saml2pName "StatusCode") >=>
+            parseStatusCodeValue isTopLevel
+    let statusCodeSubordinate = listToMaybe (
+            cursor $/
+                element (saml2pName "Status") &/
+                element (saml2pName "StatusCode")) >>=
+                parseStatusCode False
+
+    pure MkStatusCode{..}
+
+-- | `parseStatusCodeValue` @isTopLevel cursor@ attempts to parse a status code
+-- value from the XML @cursor@. The @isTopLevel@ value determines which values
+-- we permit as valid status code values. See the note for `parseStatusCode`.
+--
+-- @since 0.4
+parseStatusCodeValue :: MonadFail m => Bool -> Cursor -> m StatusCodeValue
+parseStatusCodeValue isTopLevel cursor =
+    case T.concat $ attribute "Value" cursor of
+        -- the following status codes are always permitted
+        "urn:oasis:names:tc:SAML:2.0:status:Success" -> pure Success
+        "urn:oasis:names:tc:SAML:2.0:status:Requester" -> pure Requester
+        "urn:oasis:names:tc:SAML:2.0:status:Responder" -> pure Responder
+        "urn:oasis:names:tc:SAML:2.0:status:VersionMismatch" ->
+            pure VersionMismatch
+        -- the following are only permitted for subordinate elements
+        "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed" | not isTopLevel ->
+            pure AuthnFailed
+        "urn:oasis:names:tc:SAML:2.0:status:InvalidAttrNameOrValue" | not isTopLevel ->
+            pure InvalidAttrNameOrValue
+        "urn:oasis:names:tc:SAML:2.0:status:InvalidNameIDPolicy" | not isTopLevel ->
+            pure InvalidNameIDPolicy
+        "urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext" | not isTopLevel ->
+            pure NoAuthnContext
+        "urn:oasis:names:tc:SAML:2.0:status:NoAvailableIDP" | not isTopLevel ->
+            pure NoAvailableIDP
+        "urn:oasis:names:tc:SAML:2.0:status:NoPassive" | not isTopLevel ->
+            pure NoPassive
+        "urn:oasis:names:tc:SAML:2.0:status:NoSupportedIDP" | not isTopLevel ->
+            pure NoSupportedIDP
+        "urn:oasis:names:tc:SAML:2.0:status:PartialLogout" | not isTopLevel ->
+            pure PartialLogout
+        "urn:oasis:names:tc:SAML:2.0:status:ProxyCountExceeded" | not isTopLevel ->
+            pure ProxyCountExceeded
+        "urn:oasis:names:tc:SAML:2.0:status:RequestDenied" | not isTopLevel ->
+            pure RequestDenied
+        "urn:oasis:names:tc:SAML:2.0:status:RequestUnsupported" | not isTopLevel ->
+            pure RequestUnsupported
+        "urn:oasis:names:tc:SAML:2.0:status:RequestVersionDeprecated" | not isTopLevel ->
+            pure RequestVersionDeprecated
+        "urn:oasis:names:tc:SAML:2.0:status:RequestVersionTooHigh" | not isTopLevel ->
+            pure RequestVersionTooHigh
+        "urn:oasis:names:tc:SAML:2.0:status:RequestVersionTooLow" | not isTopLevel ->
+            pure RequestVersionTooLow
+        "urn:oasis:names:tc:SAML:2.0:status:ResourceNotRecognized" | not isTopLevel ->
+            pure ResourceNotRecognized
+        "urn:oasis:names:tc:SAML:2.0:status:TooManyResponses" | not isTopLevel ->
+            pure TooManyResponses
+        "urn:oasis:names:tc:SAML:2.0:status:UnknownAttrProfile" | not isTopLevel ->
+            pure UnknownAttrProfile
+        "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal" | not isTopLevel ->
+            pure UnknownPrincipal
+        "urn:oasis:names:tc:SAML:2.0:status:UnsupportedBinding" | not isTopLevel ->
+            pure UnsupportedBinding
+        uriString | not isTopLevel -> case parseURI $ T.unpack uriString of
+            Nothing -> fail $ "Not a valid status code: " <> T.unpack uriString
+            Just uri -> pure $ OtherStatus uri
+        -- not a valid URI or a status code that's not supported at the
+        -- top-level
+        xs -> fail $ "Not a valid status code: " <> T.unpack xs
 
 --------------------------------------------------------------------------------

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -89,9 +89,9 @@ validateSAMLResponse :: SAML2Config
 validateSAMLResponse cfg responseXmlDoc samlResponse now = do
 
     -- check that the response indicates success
-    case responseStatusCode samlResponse of
+    case statusCodeValue $ responseStatusCode samlResponse of
         Success -> pure ()
-        status -> throwError $ Unsuccessful status
+        _status -> throwError $ Unsuccessful $ responseStatusCode samlResponse
 
     -- check that the destination is as expected, if the configuration
     -- expects us to validate this

--- a/tests/data/google.xml.expected
+++ b/tests/data/google.xml.expected
@@ -9,7 +9,9 @@ Response
   , responseVersion = "2.0"
   , responseIssuer =
       "https://accounts.google.com/o/saml2?idpid=C01aa60hc"
-  , responseStatusCode = Success
+  , responseStatusCode =
+      MkStatusCode
+        { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
       Signature
         { signatureInfo =

--- a/tests/data/keycloak.xml.expected
+++ b/tests/data/keycloak.xml.expected
@@ -6,7 +6,9 @@ Response
   , responseIssueInstant = 2022-08-01 00:32:49.365 UTC
   , responseVersion = "2.0"
   , responseIssuer = "http://localhost:8080/realms/HERP"
-  , responseStatusCode = Success
+  , responseStatusCode =
+      MkStatusCode
+        { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
       Signature
         { signatureInfo =

--- a/tests/data/okta.xml.expected
+++ b/tests/data/okta.xml.expected
@@ -6,7 +6,9 @@ Response
   , responseIssueInstant = 2022-07-28 13:53:54.059 UTC
   , responseVersion = "2.0"
   , responseIssuer = "http://www.okta.com/exk1s7jqodj4muVTl697"
-  , responseStatusCode = Success
+  , responseStatusCode =
+      MkStatusCode
+        { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
       Signature
         { signatureInfo =

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -68,6 +68,7 @@ library
     , data-default-class <1
     , http-types <1
     , mtl >=2.2.1 && <3
+    , network-uri >=2.0 && <3
     , text <2.1
     , time >=1.9 && <2
     , vault >=0.3 && <1
@@ -103,6 +104,7 @@ test-suite parser
     , filepath
     , http-types <1
     , mtl >=2.2.1 && <3
+    , network-uri >=2.0 && <3
     , pretty-show
     , tasty
     , tasty-golden


### PR DESCRIPTION
This PR fixes #32 by handling status codes according to the SAML2 specification.

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
