### PR TITLE
Support signed assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Replaced `x509Certificate` with `x509Certificates` in `IDPSSODescriptor` so that it may have more than one certificate ([#65](https://github.com/mbg/wai-saml2/pull/65) by [@fumieval](https://github.com/fumieval))
 -   Added `attributeValues` to `AssertionAttribute` in order to handle multiple attribute values with the same name ([#67](https://github.com/mbg/wai-saml2/pull/67) by [@fumieval](https://github.com/fumieval))
+-   Support signed assertions, not just signed responses by ([#45](https://github.com/mbg/wai-saml2/pull/45) by [@fumieval](https://github.com/mbg/wai-saml2))
 
 ## 0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 -   Replaced `x509Certificate` with `x509Certificates` in `IDPSSODescriptor` so that it may have more than one certificate ([#65](https://github.com/mbg/wai-saml2/pull/65) by [@fumieval](https://github.com/fumieval))
 -   Added `attributeValues` to `AssertionAttribute` in order to handle multiple attribute values with the same name ([#67](https://github.com/mbg/wai-saml2/pull/67) by [@fumieval](https://github.com/fumieval))
--   Support signed assertions, not just signed responses by ([#45](https://github.com/mbg/wai-saml2/pull/45) by [@fumieval](https://github.com/mbg/wai-saml2))
+-   Support signed assertions, not just signed responses by ([#45](https://github.com/mbg/wai-saml2/pull/45) by [@fumieval](https://github.com/fumieval))
 
 ## 0.6
 

--- a/src/Network/Wai/SAML2/Assertion.hs
+++ b/src/Network/Wai/SAML2/Assertion.hs
@@ -31,6 +31,7 @@ import Data.Time
 import Text.XML.Cursor
 
 import Network.Wai.SAML2.NameIDFormat
+import Network.Wai.SAML2.Signature
 import Network.Wai.SAML2.XML
 
 --------------------------------------------------------------------------------
@@ -278,7 +279,9 @@ data Assertion = Assertion {
     -- | The authentication statement included in the assertion.
     assertionAuthnStatement :: !AuthnStatement,
     -- | The assertion's attribute statement.
-    assertionAttributeStatement :: !AttributeStatement
+    assertionAttributeStatement :: !AttributeStatement,
+    -- | The assertion's signature.
+    assertionSignature :: !(Maybe Signature)
 } deriving (Eq, Show)
 
 -- Reference [Assertion]
@@ -306,7 +309,9 @@ instance FromXML Assertion where
             assertionAuthnStatement = authnStatement,
             assertionAttributeStatement =
                 cursor $/ element (saml2Name "AttributeStatement")
-                    >=> parseAttributeStatement
+                    >=> parseAttributeStatement,
+            assertionSignature = listToMaybe $
+                cursor $/ element (dsName "Signature") >=> parseXML
         }
 
 --------------------------------------------------------------------------------

--- a/src/Network/Wai/SAML2/Config.hs
+++ b/src/Network/Wai/SAML2/Config.hs
@@ -8,6 +8,7 @@
 -- | Configuration types and smart constructors for the SAML2 middleware.
 module Network.Wai.SAML2.Config (
     SAML2Config(..),
+    ValidationTarget(..),
     saml2Config,
     saml2ConfigNoEncryption
 ) where
@@ -50,8 +51,17 @@ data SAML2Config = SAML2Config {
     -- | Always decrypt assertions using 'saml2PrivateKey' and reject plaintext assertions.
     --
     -- @since 0.4
-    saml2RequireEncryptedAssertion :: !Bool
+    saml2RequireEncryptedAssertion :: !Bool,
+
+    -- | Which part of the SAML2 response to validate.
+    saml2ValidationTarget :: !ValidationTarget
 }
+
+-- | Which part of the SAML2 response to validate.
+data ValidationTarget
+    = ValidateAssertion
+    | ValidateResponse
+    | ValidateEither
 
 -- | 'saml2Config' @privateKey publicKey@ constructs a 'SAML2Config' value
 -- with the most basic set of options possible using @privateKey@ as the
@@ -79,7 +89,8 @@ saml2ConfigNoEncryption pubKey = SAML2Config{
     saml2ExpectedDestination = Nothing,
     saml2Audiences = [],
     saml2DisableTimeValidation = False,
-    saml2RequireEncryptedAssertion = False
+    saml2RequireEncryptedAssertion = False,
+    saml2ValidationTarget = ValidateResponse
 }
 
 --------------------------------------------------------------------------------

--- a/src/Network/Wai/SAML2/Error.hs
+++ b/src/Network/Wai/SAML2/Error.hs
@@ -73,6 +73,12 @@ data SAML2Error
     --
     -- @since 0.4
     | EncryptedAssertionNotSupported
+    -- | The response is missing an assertion.
+    | AssertionMissing
+    -- | The response is missing a signature for the assertion.
+    | AssertionSignatureMissing
+    -- | The response is missing a signature for the response.
+    | ResponseSignatureMissing
     deriving Show
 
 --------------------------------------------------------------------------------

--- a/src/Network/Wai/SAML2/Response.hs
+++ b/src/Network/Wai/SAML2/Response.hs
@@ -56,7 +56,7 @@ data Response = Response {
     -- | The status of the response.
     responseStatusCode :: !StatusCode,
     -- | The response signature.
-    responseSignature :: !Signature,
+    responseSignature :: !(Maybe Signature),
     -- | The unencrypted assertion.
     --
     -- @since 0.4
@@ -88,9 +88,6 @@ instance FromXML Response where
                     $/  element (saml2Name "EncryptedAssertion")
                     ) >>= parseXML
 
-        signature <- oneOrFail "Signature is required" (
-            cursor $/ element (dsName "Signature") ) >>= parseXML
-
         pure Response{
             responseDestination = T.concat $ attribute "Destination" cursor,
             responseId = T.concat $ attribute "ID" cursor,
@@ -100,7 +97,8 @@ instance FromXML Response where
             responseIssuer = T.concat $
                 cursor $/ element (saml2Name "Issuer") &/ content,
             responseStatusCode = statusCode,
-            responseSignature = signature,
+            responseSignature = listToMaybe $
+                (cursor $/ element (dsName "Signature")) >>= parseXML,
             responseAssertion = assertion,
             responseEncryptedAssertion = encAssertion
         }

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -139,6 +139,7 @@ data ValidationContext = ValidationContext
     , docMinusSignature :: XML.Document
     }
 
+-- | Validate a response signature and return the assertion.
 validateSAMLResponseSignature :: SAML2Config
                      -> XML.Document
                      -> Response
@@ -263,6 +264,7 @@ validateSAMLSignature ValidationContext{..} = do
     -- all checks out, return the assertion
     pure assertion
 
+-- | Validate the signature of an assertion and return the assertion.
 validateSAMLAssertionSignature :: SAML2Config -> XML.Document -> Response -> UTCTime -> ExceptT SAML2Error IO Assertion
 validateSAMLAssertionSignature cfg responseXmlDoc samlResponse now = do
     assertion <- case responseAssertion samlResponse of

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -125,9 +125,14 @@ validateSAMLResponse cfg responseXmlDoc samlResponse now = do
 
     validateSAMLPreliminary cfg samlResponse
 
-    case responseSignature samlResponse of
-        Just signature -> validateSAMLResponseSignature cfg responseXmlDoc samlResponse signature now
-        Nothing -> validateSAMLAssertionSignature cfg responseXmlDoc samlResponse now
+    case saml2ValidationTarget cfg of
+        ValidateAssertion -> validateSAMLAssertionSignature cfg responseXmlDoc samlResponse now
+        ValidateResponse -> case responseSignature samlResponse of
+            Just signature -> validateSAMLResponseSignature cfg responseXmlDoc samlResponse signature now
+            Nothing -> throwError ResponseSignatureMissing
+        ValidateEither -> case responseSignature samlResponse of
+            Just signature -> validateSAMLResponseSignature cfg responseXmlDoc samlResponse signature now
+            Nothing -> validateSAMLAssertionSignature cfg responseXmlDoc samlResponse now
 
 data ValidationContext = ValidationContext
     { cfg :: SAML2Config

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -129,6 +129,16 @@ validateSAMLResponse cfg responseXmlDoc samlResponse now = do
         Just _ -> validateSAMLResponseSignature cfg responseXmlDoc samlResponse now
         Nothing -> validateSAMLAssertionSignature cfg responseXmlDoc samlResponse now
 
+data ValidationContext = ValidationContext
+    { cfg :: SAML2Config
+    , responseXmlDoc :: XML.Document
+    , samlResponse :: Response
+    , now :: UTCTime
+    , signedInfo :: XML.Element
+    , signature :: Signature
+    , docMinusSignature :: XML.Document
+    }
+
 validateSAMLResponseSignature :: SAML2Config
                      -> XML.Document
                      -> Response
@@ -169,16 +179,6 @@ validateSAMLResponseSignature cfg responseXmlDoc samlResponse now = do
     let docMinusSignature = removeSignature responseXmlDoc
 
     validateSAMLSignature ValidationContext{..}
-
-data ValidationContext = ValidationContext
-    { cfg :: !SAML2Config
-    , docMinusSignature :: !XML.Document
-    , now :: !UTCTime
-    , responseXmlDoc :: !XML.Document
-    , samlResponse :: !Response
-    , signature :: !Signature
-    , signedInfo :: !XML.Element
-    }
 
 validateSAMLSignature :: ValidationContext -> ExceptT SAML2Error IO Assertion
 validateSAMLSignature ValidationContext{..} = do

--- a/tests/Validation.hs
+++ b/tests/Validation.hs
@@ -11,7 +11,6 @@ import Network.Wai.SAML2
 import Network.Wai.SAML2.Validation
 import System.FilePath
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
 
 -- | Get a public key from a X.509 certificate
@@ -46,7 +45,7 @@ tests :: TestTree
 tests = testGroup "Validate SAML2 Response"
     [ testCase "AzureAD signed response"
         $ run "azuread.crt" "2023-05-10T01:20:00Z" "azuread-signed-response.xml"
-    , expectFail $ testCase "AzureAD signed assertion"
+    , testCase "AzureAD signed assertion"
         $ run "azuread.crt" "2023-05-09T16:00:00Z" "azuread-signed-assertion.xml"
     , testCase "Okta with AttributeStatement"
         $ run "okta.crt" "2023-06-16T06:43:00.000Z" "okta-attributes.xml"

--- a/tests/Validation.hs
+++ b/tests/Validation.hs
@@ -28,7 +28,9 @@ run certPath timestamp respPath = do
     now <- iso8601ParseM timestamp
 
     let pub = parseCertificate cert
-        cfg = saml2ConfigNoEncryption pub
+        cfg = (saml2ConfigNoEncryption pub) {
+            saml2ValidationTarget = ValidateEither
+        }
 
     assertion <- runExceptT $ do
         (responseXmlDoc, samlResponse) <- decodeResponse $ Base64.encode xml

--- a/tests/data/google.xml.expected
+++ b/tests/data/google.xml.expected
@@ -13,22 +13,23 @@ Response
       MkStatusCode
         { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
-      Signature
-        { signatureInfo =
-            SignedInfo
-              { signedInfoCanonicalisationMethod = C14N_EXC_1_0
-              , signedInfoSignatureMethod = RSA_SHA256
-              , signedInfoReference =
-                  Reference
-                    { referenceURI = "_b9917f3478ff3f776cb351547379d0bc"
-                    , referenceDigestMethod = DigestSHA256
-                    , referenceDigestValue =
-                        "z3YXe+aIiyAYbSGqxRiYPwTO38JNZad2WBgqinjiX8g="
-                    }
-              }
-        , signatureValue =
-            "S6IAb+4yYyNVIfnqM7ZIrFSKbzi0RgVqk6qNL0ehzFZhcaArqN/8S0oCDrrc+0B2ygCkpbDKt03/\nvNIxq862VYa1Y39n8w0/eIKc+m3beNS6e+n316o3LCtSTPvgC2kE96Jh44MOUX9z/KIYxXiPGgdi\nnnlxK6L1dZGrMKKBxEFiBJMhFI42gWADyrUz311PDImM+rVhINJT9NyD1i1G++PILLer/BlGwg5n\nwNQHmjt4pV3m+8zMMIrfLjZT/YX8s7+1Xn1Y3bMzo6PnsbvS7OX1YGuN4cPn9f4MLu5Vcn9lWo/r\n+zuZay/pS0mEqTmeOOMGk4BOseiU/hAra5NDgQ=="
-        }
+      Just
+        Signature
+          { signatureInfo =
+              SignedInfo
+                { signedInfoCanonicalisationMethod = C14N_EXC_1_0
+                , signedInfoSignatureMethod = RSA_SHA256
+                , signedInfoReference =
+                    Reference
+                      { referenceURI = "_b9917f3478ff3f776cb351547379d0bc"
+                      , referenceDigestMethod = DigestSHA256
+                      , referenceDigestValue =
+                          "z3YXe+aIiyAYbSGqxRiYPwTO38JNZad2WBgqinjiX8g="
+                      }
+                }
+          , signatureValue =
+              "S6IAb+4yYyNVIfnqM7ZIrFSKbzi0RgVqk6qNL0ehzFZhcaArqN/8S0oCDrrc+0B2ygCkpbDKt03/\nvNIxq862VYa1Y39n8w0/eIKc+m3beNS6e+n316o3LCtSTPvgC2kE96Jh44MOUX9z/KIYxXiPGgdi\nnnlxK6L1dZGrMKKBxEFiBJMhFI42gWADyrUz311PDImM+rVhINJT9NyD1i1G++PILLer/BlGwg5n\nwNQHmjt4pV3m+8zMMIrfLjZT/YX8s7+1Xn1Y3bMzo6PnsbvS7OX1YGuN4cPn9f4MLu5Vcn9lWo/r\n+zuZay/pS0mEqTmeOOMGk4BOseiU/hAra5NDgQ=="
+          }
   , responseAssertion =
       Just
         Assertion
@@ -72,6 +73,7 @@ Response
                 , authnStatementLocality = ""
                 }
           , assertionAttributeStatement = []
+          , assertionSignature = Nothing
           }
   , responseEncryptedAssertion = Nothing
   }

--- a/tests/data/keycloak.xml.expected
+++ b/tests/data/keycloak.xml.expected
@@ -10,22 +10,23 @@ Response
       MkStatusCode
         { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
-      Signature
-        { signatureInfo =
-            SignedInfo
-              { signedInfoCanonicalisationMethod = C14N_EXC_1_0
-              , signedInfoSignatureMethod = RSA_SHA256
-              , signedInfoReference =
-                  Reference
-                    { referenceURI = "ID_5b1d000b-3a5e-4dfe-aa4e-b7bf1e3efbfd"
-                    , referenceDigestMethod = DigestSHA256
-                    , referenceDigestValue =
-                        "/U47P3hsUf+tUyyglYF8M1u6lbVnHimCthtxusju4mo="
-                    }
-              }
-        , signatureValue =
-            "b9vgIBQ1yNvUYgNmfAyuQJXOJ68PMfRvNAZEa93tnzZXHPEsf7/F49xI6/mlYI/T9pDxYnFcfl7kPMxgz4ssvMjwUEgAR3G3ZrNv4gPMUPmbZnXe0KG8yU9AskK90ya/T11kQfI21cSlA8FrLPTGP2X97yErR10mIDvEJ/m5dWra95cGLx/ntjaSIqNJpVgpHhRxieS4Lw+zeWe/nVuznXQnb8VRhCq18ikL/u23+YhYT3ws3iXQssJ2BosX9JJt0O+X31sIHJIWHsxbI69NLJ782bVDDkI1PNF8MKoa8gSEiLsNSmp3SyXtMPzaRIBguksl9xbnmYmsJDQg6kFVlQ=="
-        }
+      Just
+        Signature
+          { signatureInfo =
+              SignedInfo
+                { signedInfoCanonicalisationMethod = C14N_EXC_1_0
+                , signedInfoSignatureMethod = RSA_SHA256
+                , signedInfoReference =
+                    Reference
+                      { referenceURI = "ID_5b1d000b-3a5e-4dfe-aa4e-b7bf1e3efbfd"
+                      , referenceDigestMethod = DigestSHA256
+                      , referenceDigestValue =
+                          "/U47P3hsUf+tUyyglYF8M1u6lbVnHimCthtxusju4mo="
+                      }
+                }
+          , signatureValue =
+              "b9vgIBQ1yNvUYgNmfAyuQJXOJ68PMfRvNAZEa93tnzZXHPEsf7/F49xI6/mlYI/T9pDxYnFcfl7kPMxgz4ssvMjwUEgAR3G3ZrNv4gPMUPmbZnXe0KG8yU9AskK90ya/T11kQfI21cSlA8FrLPTGP2X97yErR10mIDvEJ/m5dWra95cGLx/ntjaSIqNJpVgpHhRxieS4Lw+zeWe/nVuznXQnb8VRhCq18ikL/u23+YhYT3ws3iXQssJ2BosX9JJt0O+X31sIHJIWHsxbI69NLJ782bVDDkI1PNF8MKoa8gSEiLsNSmp3SyXtMPzaRIBguksl9xbnmYmsJDQg6kFVlQ=="
+          }
   , responseAssertion = Nothing
   , responseEncryptedAssertion =
       Just

--- a/tests/data/okta.xml.expected
+++ b/tests/data/okta.xml.expected
@@ -10,22 +10,23 @@ Response
       MkStatusCode
         { statusCodeValue = Success , statusCodeSubordinate = Nothing }
   , responseSignature =
-      Signature
-        { signatureInfo =
-            SignedInfo
-              { signedInfoCanonicalisationMethod = C14N_EXC_1_0
-              , signedInfoSignatureMethod = RSA_SHA256
-              , signedInfoReference =
-                  Reference
-                    { referenceURI = "id36905492230634463108368061"
-                    , referenceDigestMethod = DigestSHA256
-                    , referenceDigestValue =
-                        "i300U58mYoywmpgMkq7AHOplar4B6ZwW++Ri3PUvGlc="
-                    }
-              }
-        , signatureValue =
-            "eKymDiZIxFd+oJCIhdHQpI+s2nQYFBVH7TBoZaqXizJdNnNPpNlKM5wds33zP6a72GWOL/2n8WRtW+xSnPTmw5PumEuUhWbO2EizfU/SdBL4HKxxJt0nntkDRhdIoHBi+9Gy80So4NGr82B2clnhpj74GW0Ko8A0bt2sHzdQ9NaJ5ru4Qvx0Fk/UCBAGAYobryjAc9Tb5qxxgHGMmPUHG5CprRYTINKZlGF1Jl88VSdTbOYmGjJ4b6GY8pLR2qLt4LErVPUSI4vEUuPFU2f/9/i8D39hzWtJOCzuaUZ5tdKU3Fyjsgoa7ooDfZVzb4howWhQ9zPUgwjZEd9tbW2EwA=="
-        }
+      Just
+        Signature
+          { signatureInfo =
+              SignedInfo
+                { signedInfoCanonicalisationMethod = C14N_EXC_1_0
+                , signedInfoSignatureMethod = RSA_SHA256
+                , signedInfoReference =
+                    Reference
+                      { referenceURI = "id36905492230634463108368061"
+                      , referenceDigestMethod = DigestSHA256
+                      , referenceDigestValue =
+                          "i300U58mYoywmpgMkq7AHOplar4B6ZwW++Ri3PUvGlc="
+                      }
+                }
+          , signatureValue =
+              "eKymDiZIxFd+oJCIhdHQpI+s2nQYFBVH7TBoZaqXizJdNnNPpNlKM5wds33zP6a72GWOL/2n8WRtW+xSnPTmw5PumEuUhWbO2EizfU/SdBL4HKxxJt0nntkDRhdIoHBi+9Gy80So4NGr82B2clnhpj74GW0Ko8A0bt2sHzdQ9NaJ5ru4Qvx0Fk/UCBAGAYobryjAc9Tb5qxxgHGMmPUHG5CprRYTINKZlGF1Jl88VSdTbOYmGjJ4b6GY8pLR2qLt4LErVPUSI4vEUuPFU2f/9/i8D39hzWtJOCzuaUZ5tdKU3Fyjsgoa7ooDfZVzb4howWhQ9zPUgwjZEd9tbW2EwA=="
+          }
   , responseAssertion = Nothing
   , responseEncryptedAssertion =
       Just


### PR DESCRIPTION
**Summary**

At the moment, wai-saml2 validates signed responses, but not signed assertions. This might cause an error when the identity provider signs assertions only (by default AzureAD does not sign responses).
This change adds support for signed assertions; when a signature for the response is present, it validates the response. If this is missing, it validates the signature for the assertion instead.

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
