### PR TITLE
add test/data/metadata/* to extra-source-files (fixes #44)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,6 +14,7 @@ extra-source-files:
   - README.md
   - CHANGELOG.md
   - tests/data/**
+  - tests/data/metadata/**
 
 default-extensions:
   - FlexibleInstances

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -26,6 +26,10 @@ extra-source-files:
     tests/data/keycloak.xml.expected
     tests/data/okta.xml
     tests/data/okta.xml.expected
+    tests/data/metadata/google.xml
+    tests/data/metadata/google.xml.expected
+    tests/data/metadata/keycloak.xml
+    tests/data/metadata/keycloak.xml.expected
 
 source-repository head
   type: git


### PR DESCRIPTION
**Summary**

This PR adds some test assets missing in extra-source-files. Fixes #44


**Checklist**

- [ ] All definitions are documented with Haddock-style comments.
- [ ] All exported definitions have `@since` annotations.
- [ ] Code is formatted in line with the existing code.
- [ ] The changelog has been updated.
