### PR TITLE
Add destination field to AuthnRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `wai-saml2`
 
+## 0.4.1
+
+- Added `authnRequestDestination` field to `AuthnRequest`
+
 ## 0.4
 
 -   Split `validateResponse` into `decodeResponse` and `validateSAMLResponse` ([#31](https://github.com/mbg/wai-saml2/pull/31) by [@fumieval](https://github.com/fumieval))

--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -63,6 +63,11 @@ data AuthnRequest
     ,   authnRequestID :: !T.Text
         -- | SP Entity ID
     ,   authnRequestIssuer :: !T.Text
+        -- | The URI reference to which this request is to be sent. Required
+        -- for signed requests
+        --
+        -- @since 0.4.1
+    ,   authnRequestDestination :: !(Maybe T.Text)
         -- | Allow IdP to generate a new identifier
     ,   authnRequestAllowCreate :: !Bool
         -- | The URI reference corresponding to a name identifier format
@@ -83,6 +88,7 @@ issueAuthnRequest authnRequestIssuer = do
     pure AuthnRequest{
         authnRequestAllowCreate = True
     ,   authnRequestNameIDFormat = Transient
+    ,   authnRequestDestination = Nothing
     ,   ..
     }
 
@@ -118,13 +124,15 @@ renderXML AuthnRequest{..} =
         root = Element
             (saml2pName "AuthnRequest")
             (Map.fromList
-                [ ("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+               ([ ("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
                 , ("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
                 , ("ID", authnRequestID) -- Reference [RequestAbstractType] and see [ID Values]
                 , ("Version", "2.0")  -- [RequestAbstractType]
                 , ("IssueInstant", timestamp) -- [RequestAbstractType]
                 , ("AssertionConsumerServiceIndex", "1") -- [AuthnRequest]
-                ])
+                ]
+                -- [RequestAbstractType]
+                ++ [("Destination", uri) | let Just uri = authnRequestDestination] ))
             [NodeElement issuer, NodeElement nameIdPolicy]
         -- Reference [RequestAbstractType]
         issuer = Element


### PR DESCRIPTION
**Summary**
`AuthnRequest` has an optional attribute, `Destination`, which is however required for signed requests. This PR adds this attribute.

<!-- Summarise what changes your PR makes and why. -->

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
