### PR TITLE
Use `crypton-*` packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+-   Switch from `x509-*` to `crypton-x509-*`.
+
 ## 0.5
 
 -   Support GHC 9.6 ([#53](https://github.com/mbg/wai-saml2/pull/53) by [@mbg](https://github.com/mbg))

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ dependencies:
   - bytestring >= 0.9 && < 0.13
   - c14n >= 0.1.0.1 && < 1
   - containers >= 0.6 && <0.7
-  - cryptonite < 1
+  - crypton < 1
   - data-default-class < 1
   - http-types < 1
   - mtl >= 2.2.1 && < 3
@@ -38,8 +38,8 @@ dependencies:
   - vault >= 0.3 && < 1
   - wai >= 3.0 && < 4
   - wai-extra >= 3.0 && < 4
-  - x509 < 2
-  - x509-store < 2
+  - crypton-x509 < 2
+  - crypton-x509-store < 2
   - xml-conduit < 2
   - zlib >= 0.6.0.0 && < 0.8
 

--- a/stack-lts-16.1.yaml
+++ b/stack-lts-16.1.yaml
@@ -1,6 +1,9 @@
 resolver: lts-16.1
 packages:
-- .
+  - .
 
 extra-deps:
-- c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+  - c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+  - crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9

--- a/stack-lts-16.1.yaml.lock
+++ b/stack-lts-16.1.yaml.lock
@@ -7,13 +7,34 @@ packages:
 - completed:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
     pantry-tree:
-      size: 285
       sha256: 67187305166a25d10cb133378ae89c3d76d51ee756edd757a84f71f176eb61e7
+      size: 285
   original:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
+    sha256: 954b6b14b0c8130732cf4773f7ebb4efc9a44600d1a5265d142868bf93462bc6
     size: 531237
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/1.yaml
-    sha256: 954b6b14b0c8130732cf4773f7ebb4efc9a44600d1a5265d142868bf93462bc6
   original: lts-16.1

--- a/stack-lts-17.14.yaml
+++ b/stack-lts-17.14.yaml
@@ -1,7 +1,10 @@
 resolver: lts-17.14
 compiler: ghc-8.10.7
 packages:
-- .
+  - .
 
 extra-deps:
-- c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+  - c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+  - crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9

--- a/stack-lts-17.14.yaml.lock
+++ b/stack-lts-17.14.yaml.lock
@@ -7,13 +7,34 @@ packages:
 - completed:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
     pantry-tree:
-      size: 285
       sha256: 67187305166a25d10cb133378ae89c3d76d51ee756edd757a84f71f176eb61e7
+      size: 285
   original:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
+    sha256: 3740f22286bf5e6e3d82f88125e1c708b6e27847211f956b530aa5d83cf39383
     size: 567677
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/14.yaml
-    sha256: 3740f22286bf5e6e3d82f88125e1c708b6e27847211f956b530aa5d83cf39383
   original: lts-17.14

--- a/stack-lts-18.yaml
+++ b/stack-lts-18.yaml
@@ -1,1 +1,6 @@
 resolver: lts-18.28
+
+extra-deps:
+  - crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9

--- a/stack-lts-18.yaml.lock
+++ b/stack-lts-18.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -1,1 +1,6 @@
 resolver: lts-19.33
+
+extra-deps:
+  - crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9

--- a/stack-lts-19.yaml.lock
+++ b/stack-lts-19.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
     sha256: 6d1532d40621957a25bad5195bfca7938e8a06d923c91bc52aa0f3c41181f2d4

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,1 +1,6 @@
-resolver: lts-20.2
+resolver: lts-20.25
+
+extra-deps:
+  - crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9

--- a/stack-lts-20.yaml.lock
+++ b/stack-lts-20.yaml.lock
@@ -3,10 +3,31 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
-    sha256: fc39d8afc97531d53d87b10abdef593bce503c0c1e46c2e9a84ebcbc78bf8470
-    size: 648432
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/2.yaml
-  original: lts-20.2
+    sha256: e63b43d506918278d05cd1448bd19352ab2faa9b8e9d64ce527b56f1a7fba149
+    size: 650255
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/25.yaml
+  original: lts-20.25

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,13 +7,34 @@ packages:
 - completed:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
     pantry-tree:
-      size: 285
       sha256: 67187305166a25d10cb133378ae89c3d76d51ee756edd757a84f71f176eb61e7
+      size: 285
   original:
     hackage: c14n-0.1.0.1@sha256:c56a513c1363d126ee704656b59d2e2af1cfe878587a97cb69ab0122b82e2d4d,1371
+- completed:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+    pantry-tree:
+      sha256: 0d73be1794796e4c87e1a20198109ec7364eee8c54dd6cf6c4d202f1f6ca3ac0
+      size: 23320
+  original:
+    hackage: crypton-0.31@sha256:c0e4aa081bd65d1cb415358ec43e83e7fe703c83b633243a89162bd6eb865850,18286
+- completed:
+    hackage: crypton-x509-1.7.6@sha256:c567657a705b6d6521f9dd2de999bf530d618ec00f3b939df76a41fb0fe94281,2339
+    pantry-tree:
+      sha256: 729e7db8dfc0a8b43e08bbd8d1387c9065e39beda6ac39e0fb9f10140810a3eb
+      size: 1080
+  original:
+    hackage: crypton-x509-1.7.6
+- completed:
+    hackage: crypton-x509-store-1.6.9@sha256:422b9b9f87a7382c66385d047615b16fc86a68c08ea22b1e0117c143a2d44050,1750
+    pantry-tree:
+      sha256: 87654d130a7f987ee139c821a1be45736d18df9fa4cb1142c4e054d3802338f3
+      size: 406
+  original:
+    hackage: crypton-x509-store-1.6.9
 snapshots:
 - completed:
+    sha256: 3740f22286bf5e6e3d82f88125e1c708b6e27847211f956b530aa5d83cf39383
     size: 567677
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/14.yaml
-    sha256: 3740f22286bf5e6e3d82f88125e1c708b6e27847211f956b530aa5d83cf39383
   original: lts-17.14

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -68,7 +68,9 @@ library
     , bytestring >=0.9 && <0.13
     , c14n >=0.1.0.1 && <1
     , containers ==0.6.*
-    , cryptonite <1
+    , crypton <1
+    , crypton-x509 <2
+    , crypton-x509-store <2
     , data-default-class <1
     , http-types <1
     , mtl >=2.2.1 && <3
@@ -78,8 +80,6 @@ library
     , vault >=0.3 && <1
     , wai >=3.0 && <4
     , wai-extra >=3.0 && <4
-    , x509 <2
-    , x509-store <2
     , xml-conduit <2
     , zlib >=0.6.0.0 && <0.8
   default-language: Haskell2010
@@ -103,7 +103,9 @@ test-suite parser
     , bytestring
     , c14n >=0.1.0.1 && <1
     , containers ==0.6.*
-    , cryptonite <1
+    , crypton <1
+    , crypton-x509 <2
+    , crypton-x509-store <2
     , data-default-class <1
     , filepath
     , http-types <1
@@ -118,8 +120,6 @@ test-suite parser
     , wai >=3.0 && <4
     , wai-extra >=3.0 && <4
     , wai-saml2
-    , x509 <2
-    , x509-store <2
     , xml-conduit
     , zlib >=0.6.0.0 && <0.8
   default-language: Haskell2010


### PR DESCRIPTION
**Summary**

Context: https://github.com/commercialhaskell/stackage/issues/6998

This PR replaces the following dependencies:

- `cryptonite` => `crypton`
- `x509` => `crypton-x509`
- `x509-store` => `crypton-x509-store`

**Checklist**

- [x] The changelog has been updated.
