### PR TITLE
Support GHC 9.6

### DIFF
--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -3,6 +3,8 @@ name: stackage-nightly
 on:
   schedule:
     - cron: "5 6 * * *"
+  workflow_dispatch:
+  pull_request:
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `wai-saml2`
 
+## Unreleased changes
+
+-   Support GHC 9.6 ([#53](https://github.com/mbg/wai-saml2/pull/53) by [@mbg](https://github.com/mbg))
+
 ## 0.4
 
 -   Split `validateResponse` into `decodeResponse` and `validateSAMLResponse` ([#31](https://github.com/mbg/wai-saml2/pull/31) by [@fumieval](https://github.com/fumieval))

--- a/src/Network/Wai/SAML2/Validation.hs
+++ b/src/Network/Wai/SAML2/Validation.hs
@@ -16,7 +16,9 @@ module Network.Wai.SAML2.Validation (
 --------------------------------------------------------------------------------
 
 import Control.Exception
+import Control.Monad (forM_, when, unless)
 import Control.Monad.Except
+import Control.Monad.IO.Class (liftIO)
 
 import Crypto.Error
 import Crypto.Hash


### PR DESCRIPTION
**Summary**

Adds additional imports to support GHC 9.6. See [GHC's change notes](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.6#mtl-23-changes).

**Checklist**

- [x] The changelog has been updated.
