### PR TITLE
Use pre-made Actions for Haskell workflows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,37 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: haskell/actions/setup@v2
-        id: install-haskell
+      - uses: mbg/actions/stack/build@main
         with:
-          stack-no-global: true
-          enable-stack: true
-          stack-version: "latest"
-
-      - name: Cache .stack
-        id: cache-stack
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.install-haskell.outputs.stack-root }}
-          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-${{ hashFiles('wai-saml2.cabal') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-
-            ${{ runner.os }}-${{ matrix.resolver }}-
-
-      - name: Install dependencies
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --test --haddock --only-dependencies --fast
-
-      - name: Build
-        run: |
-          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast \
-            --test --no-run-tests \
-            --haddock --haddock-arguments='-odocs'
-
-      - name: Upload documentation
-        uses: actions/upload-artifact@v3
-        with:
-          name: docs-${{ matrix.resolver }}
-          path: docs/
-
-      - name: Test
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast
+          resolver: ${{ matrix.resolver }}
+          upload-docs: true

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: mbg/actions/stack/build@main
+      - uses: mbg/actions/stack/build@v0.1
         with:
           resolver: ${{ matrix.resolver }}
           upload-docs: true

--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -1,4 +1,4 @@
-name: stackage-nightly
+name: "Stackage Nightly"
 
 on:
   schedule:

--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: mbg/actions/stack/nightly@main
+      - uses: mbg/actions/stack/nightly@v0.1

--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -16,26 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: haskell/actions/setup@v2
-        id: install-haskell
-        with:
-          stack-no-global: true
-          enable-stack: true
-          stack-version: "latest"
-
-      - name: Initialise stack.yaml with the nightly snapshot
-        run: |
-          rm -f stack.yaml && stack init --resolver nightly
-
-      - name: Cache .stack
-        id: cache-stack
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.install-haskell.outputs.stack-root }}
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('wai-saml2.cabal') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-
-
-      - name: Build with the nightly snapshot
-        run: |
-          stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
+      - uses: mbg/actions/stack/nightly@main


### PR DESCRIPTION
**Summary**

This is an experiment which uses pre-made, composite Actions for the Haskell build workflows. If successful, this should allow the same workflows to be used across different repos.
