### PR TITLE
Release: Version 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 0.5
+
 -   Support GHC 9.6 ([#53](https://github.com/mbg/wai-saml2/pull/53) by [@mbg](https://github.com/mbg))
 -   Fixed a bug in XML canonicalisation causing a digest mismatch on Okta when assertion attributes are present (special thanks to @hiroqn) ([#51](https://github.com/mbg/wai-saml2/pull/51) by [@fumieval](https://github.com/fumieval))
 -   Added `authnRequestDestination` field to `AuthnRequest` ([#47](https://github.com/mbg/wai-saml2/pull/47) by [@Philonous](https://github.com/Philonous))

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: wai-saml2
-version: 0.4
+version: 0.5
 github: "mbg/wai-saml2"
 license: MIT
 author: "Michael B. Gale"

--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -66,7 +66,7 @@ data AuthnRequest
         -- | The URI reference to which this request is to be sent. Required
         -- for signed requests
         --
-        -- @since 0.4.1
+        -- @since 0.5
     ,   authnRequestDestination :: !(Maybe T.Text)
         -- | Allow IdP to generate a new identifier
     ,   authnRequestAllowCreate :: !Bool

--- a/src/Network/Wai/SAML2/Response.hs
+++ b/src/Network/Wai/SAML2/Response.hs
@@ -135,6 +135,8 @@ extractSignedInfo cursor = do
     pure signedInfo
 
 -- | Obtain a list of InclusiveNamespaces entries used for exclusive XML canonicalisation.
+--
+-- @since 0.5
 extractPrefixList :: Cursor -> [T.Text]
 extractPrefixList cursor = concatMap T.words
     $ concatMap (attribute "PrefixList")

--- a/src/Network/Wai/SAML2/XML.hs
+++ b/src/Network/Wai/SAML2/XML.hs
@@ -70,6 +70,8 @@ mdName name =
 
 -- | 'ecName' @name@ constructs a 'Name' for @name@ in the
 -- http://www.w3.org/2001/10/xml-exc-c14n# namespace.
+--
+-- @since 0.5
 ecName :: T.Text -> Name
 ecName name =
     Name name (Just "http://www.w3.org/2001/10/xml-exc-c14n#") (Just "ec")
@@ -111,5 +113,7 @@ oneOrFail _ (x:_) = pure x
 
 -- | It is important to retain namespaces in order to calculate the hash of the canonicalised XML correctly.
 -- see: https://stackoverflow.com/questions/69252831/saml-2-0-digest-value-calculation-in-saml-assertion
+--
+-- @since 0.5
 parseSettings :: ParseSettings
 parseSettings = def { psRetainNamespaces = True }

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           wai-saml2
-version:        0.4
+version:        0.5
 synopsis:       SAML2 assertion validation as WAI middleware
 description:    A Haskell library which implements SAML2 assertion validation as WAI middleware
 category:       Security


### PR DESCRIPTION
**Summary**

Prepares the repository for release of version 0.5. This release primarily aims to enable re-inclusion of the package in the Stackage index. The major version bump is necessary due to the changed type of `canonicalise`, which is exported.

