### PR TITLE
Support GHC 9.10

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - base64-bytestring >= 0.1 && < 2
   - bytestring >= 0.9 && < 0.13
   - c14n >= 0.1.0.1 && < 1
-  - containers >= 0.6 && <0.7
+  - containers >= 0.6 && <0.8
   - crypton < 2
   - data-default-class < 1
   - http-types < 1

--- a/wai-saml2.cabal
+++ b/wai-saml2.cabal
@@ -67,7 +67,7 @@ library
     , base64-bytestring >=0.1 && <2
     , bytestring >=0.9 && <0.13
     , c14n >=0.1.0.1 && <1
-    , containers ==0.6.*
+    , containers >=0.6 && <0.8
     , crypton <2
     , crypton-x509 <2
     , crypton-x509-store <2
@@ -102,7 +102,7 @@ test-suite parser
     , base64-bytestring >=0.1 && <2
     , bytestring
     , c14n >=0.1.0.1 && <1
-    , containers ==0.6.*
+    , containers >=0.6 && <0.8
     , crypton <2
     , crypton-x509 <2
     , crypton-x509-store <2


### PR DESCRIPTION
**Summary**

- Increases the upper bound for `containers` to `<0.8` (Resolves #61)

**Checklist**

- [ ] All definitions are documented with Haddock-style comments.
- [ ] All exported definitions have `@since` annotations.
- [ ] Code is formatted in line with the existing code.
- [ ] The changelog has been updated.
