### PR TITLE
EntityDescriptor: allow multiple certificates in IDPSSODescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `wai-saml2`
 
+## 0.7
+
+-   Replaced `x509Certificate` with `x509Certificates` in `IDPSSODescriptor` so that it may have more than one certificate ([#65](https://github.com/mbg/wai-saml2/pull/65) by [@fumieval](https://github.com/fumieval))
+
 ## 0.6
 
 -   Switch from `x509-*` to `crypton-x509-*` ([#50](https://github.com/mbg/wai-saml2/pull/50) by [@mbg](https://github.com/mbg)).

--- a/tests/data/metadata/google.xml.expected
+++ b/tests/data/metadata/google.xml.expected
@@ -1,131 +1,140 @@
 IDPSSODescriptor
   { entityID = "https://accounts.google.com/o/saml2?idpid=C01aa60hc"
-  , x509Certificate =
-      SignedExact
-        { getSigned =
-            Signed
-              { signedObject =
-                  Certificate
-                    { certVersion = 2
-                    , certSerial = 1658395081277
-                    , certSignatureAlg = SignatureALG HashSHA256 PubKeyALG_RSA
-                    , certIssuerDN =
-                        DistinguishedName
-                          { getDistinguishedElements =
-                              [ ( [ 2 , 5 , 4 , 10 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google Inc."
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 7 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Mountain View"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 3 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 11 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google For Work"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 6 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "US"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 8 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "California"
-                                    }
-                                )
-                              ]
-                          }
-                    , certValidity =
-                        ( DateTime
-                            { dtDate =
-                                Date { dateYear = 2022 , dateMonth = July , dateDay = 21 }
-                            , dtTime =
-                                TimeOfDay
-                                  { todHour = 9 h , todMin = 18 m , todSec = 0 s , todNSec = 0 ns }
+  , x509Certificates =
+      [ SignedExact
+          { getSigned =
+              Signed
+                { signedObject =
+                    Certificate
+                      { certVersion = 2
+                      , certSerial = 1658395081277
+                      , certSignatureAlg = SignatureALG HashSHA256 PubKeyALG_RSA
+                      , certIssuerDN =
+                          DistinguishedName
+                            { getDistinguishedElements =
+                                [ ( [ 2 , 5 , 4 , 10 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google Inc."
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 7 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Mountain View"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 3 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 11 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google For Work"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 6 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "US"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 8 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "California"
+                                      }
+                                  )
+                                ]
                             }
-                        , DateTime
-                            { dtDate =
-                                Date { dateYear = 2027 , dateMonth = July , dateDay = 20 }
-                            , dtTime =
-                                TimeOfDay
-                                  { todHour = 9 h , todMin = 18 m , todSec = 0 s , todNSec = 0 ns }
+                      , certValidity =
+                          ( DateTime
+                              { dtDate =
+                                  Date { dateYear = 2022 , dateMonth = July , dateDay = 21 }
+                              , dtTime =
+                                  TimeOfDay
+                                    { todHour = 9 h
+                                    , todMin = 18 m
+                                    , todSec = 0 s
+                                    , todNSec = 0 ns
+                                    }
+                              }
+                          , DateTime
+                              { dtDate =
+                                  Date { dateYear = 2027 , dateMonth = July , dateDay = 20 }
+                              , dtTime =
+                                  TimeOfDay
+                                    { todHour = 9 h
+                                    , todMin = 18 m
+                                    , todSec = 0 s
+                                    , todNSec = 0 ns
+                                    }
+                              }
+                          )
+                      , certSubjectDN =
+                          DistinguishedName
+                            { getDistinguishedElements =
+                                [ ( [ 2 , 5 , 4 , 10 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google Inc."
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 7 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Mountain View"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 3 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 11 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "Google For Work"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 6 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "US"
+                                      }
+                                  )
+                                , ( [ 2 , 5 , 4 , 8 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = Printable
+                                      , getCharacterStringRawData = "California"
+                                      }
+                                  )
+                                ]
                             }
-                        )
-                    , certSubjectDN =
-                        DistinguishedName
-                          { getDistinguishedElements =
-                              [ ( [ 2 , 5 , 4 , 10 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google Inc."
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 7 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Mountain View"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 3 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 11 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "Google For Work"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 6 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "US"
-                                    }
-                                )
-                              , ( [ 2 , 5 , 4 , 8 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = Printable
-                                    , getCharacterStringRawData = "California"
-                                    }
-                                )
-                              ]
-                          }
-                    , certPubKey =
-                        PubKeyRSA
-                          PublicKey
-                            { public_size = 256
-                            , public_n =
-                                30883043751460212091009024715988672157201981026347726370499687818828606623610036063558065564910721575436562697595833895389078194628597753679300253553943785088191301337694287320462812204176082900979493095532403911400962461718281343090255859587662209446117641661982570706673532506066365285856542563187402675519172527708567282278848705855498817485769832020293045021199187525818891914876547302505893509597998904610940749090045911784327818251262543295743496580502018384973717126996683932142133838721711519234780192895538524052074852409104614561380839223725538723547399956034683375536115322508017066877882514789596315962019
-                            , public_e = 65537
-                            }
-                    , certExtensions = Extensions Nothing
-                    }
-              , signedAlg = SignatureALG HashSHA256 PubKeyALG_RSA
-              , signedSignature =
-                  "\238\"\216Z\168\132\232\159\187\183i\152;\208\219\173\v\158\EOT\177\SO\141-\245\172o\b\SUBt\230\161o\145-\SUBpd(\RS\219j*\231M \f\180~0.sc\ACK\184\&1\179\t\241U\222Cv\185\170\166\234\CAN\248\249\247\132\ENQ\216\EOT!p\152\f\196\DC1\140&~F[MV\187\SOH\196\250o\SO\167:\161\235~v.\154\159K\133L1#\135U\225\138\246bB\203\239\174\194y#\v\191\159\ACK\ACKQ@\171\DC3\250\220uLkPI\STX\SYNa\141\169\170\189&\DLE\b\150X\156\DC1\187\&6\236\182zN\152\230A\208\&3\255\v\210\RS\167\131\GSI\191I\207\188\242>\244\217VFE!\f\223\227BL\241)\198'\b\217S\253\184\183\197\143\144\140U\131\227?\208\199h}\134\188Y\180\180mr\186zZ\165&\165xZv\173I\178d\155_\EOTc\225;\187!Vx\181\138\158c\249\142$f\US\241\250\249\135\244<\EM\DLE\157"
-              }
-        , exactObjectRaw =
-            "0\130\STX\\\160\ETX\STX\SOH\STX\STX\ACK\SOH\130 \f\186=0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\RS\ETB\r220721091800Z\ETB\r270720091800Z0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\244\164\ru\139\141\238\131\212\176\157R+b\249\241\232\SOH\DLE\182\bZ\190\\E\223O^\229u\147[6\135;v\188\202\SIKY{\243\207\191\133V\248\n\214By\166\217\fV\US4\198\210\218\137[\132m:\SYN\180\189\250\155f\218\146\174qz\132\167\226\140\244Z3\152\175\234\159\191\160y\t{\184w\\OLQ\169\245J\227\165\171D\RS\DC2\241W[+\213\136+jk\n\241\200>\237N\245\225\254\155\216>\ESCV5\215\164H\168\162\134|f\236Y\216r5\142;\248\183\&1_4\225\129\215\226\224\DC3\240p\US\226+\245\255\139\138\141\141\238\ENQ,z\192%\SO\210\233\180bMs\242\191\186\189\&1\223zGT\253\133wE\ETX\219\"[\218\230\172\144\160\252}6\217:\234\199\a-\148\137\DLE\140\241\163\202\201\ENQ\222\240\156\194\226#\228\207\SI\184\253\251\147\160.\136\SYN]W\189\224\ESC\203|J\n\f\RS\DC1%Y\"\202\163\STX\ETX\SOH\NUL\SOH"
-        , encodeSignedObject =
-            "0\130\ETXt0\130\STX\\\160\ETX\STX\SOH\STX\STX\ACK\SOH\130 \f\186=0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\RS\ETB\r220721091800Z\ETB\r270720091800Z0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\244\164\ru\139\141\238\131\212\176\157R+b\249\241\232\SOH\DLE\182\bZ\190\\E\223O^\229u\147[6\135;v\188\202\SIKY{\243\207\191\133V\248\n\214By\166\217\fV\US4\198\210\218\137[\132m:\SYN\180\189\250\155f\218\146\174qz\132\167\226\140\244Z3\152\175\234\159\191\160y\t{\184w\\OLQ\169\245J\227\165\171D\RS\DC2\241W[+\213\136+jk\n\241\200>\237N\245\225\254\155\216>\ESCV5\215\164H\168\162\134|f\236Y\216r5\142;\248\183\&1_4\225\129\215\226\224\DC3\240p\US\226+\245\255\139\138\141\141\238\ENQ,z\192%\SO\210\233\180bMs\242\191\186\189\&1\223zGT\253\133wE\ETX\219\"[\218\230\172\144\160\252}6\217:\234\199\a-\148\137\DLE\140\241\163\202\201\ENQ\222\240\156\194\226#\228\207\SI\184\253\251\147\160.\136\SYN]W\189\224\ESC\203|J\n\f\RS\DC1%Y\"\202\163\STX\ETX\SOH\NUL\SOH0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL\ETX\130\SOH\SOH\NUL\238\"\216Z\168\132\232\159\187\183i\152;\208\219\173\v\158\EOT\177\SO\141-\245\172o\b\SUBt\230\161o\145-\SUBpd(\RS\219j*\231M \f\180~0.sc\ACK\184\&1\179\t\241U\222Cv\185\170\166\234\CAN\248\249\247\132\ENQ\216\EOT!p\152\f\196\DC1\140&~F[MV\187\SOH\196\250o\SO\167:\161\235~v.\154\159K\133L1#\135U\225\138\246bB\203\239\174\194y#\v\191\159\ACK\ACKQ@\171\DC3\250\220uLkPI\STX\SYNa\141\169\170\189&\DLE\b\150X\156\DC1\187\&6\236\182zN\152\230A\208\&3\255\v\210\RS\167\131\GSI\191I\207\188\242>\244\217VFE!\f\223\227BL\241)\198'\b\217S\253\184\183\197\143\144\140U\131\227?\208\199h}\134\188Y\180\180mr\186zZ\165&\165xZv\173I\178d\155_\EOTc\225;\187!Vx\181\138\158c\249\142$f\US\241\250\249\135\244<\EM\DLE\157"
-        }
+                      , certPubKey =
+                          PubKeyRSA
+                            PublicKey
+                              { public_size = 256
+                              , public_n =
+                                  30883043751460212091009024715988672157201981026347726370499687818828606623610036063558065564910721575436562697595833895389078194628597753679300253553943785088191301337694287320462812204176082900979493095532403911400962461718281343090255859587662209446117641661982570706673532506066365285856542563187402675519172527708567282278848705855498817485769832020293045021199187525818891914876547302505893509597998904610940749090045911784327818251262543295743496580502018384973717126996683932142133838721711519234780192895538524052074852409104614561380839223725538723547399956034683375536115322508017066877882514789596315962019
+                              , public_e = 65537
+                              }
+                      , certExtensions = Extensions Nothing
+                      }
+                , signedAlg = SignatureALG HashSHA256 PubKeyALG_RSA
+                , signedSignature =
+                    "\238\"\216Z\168\132\232\159\187\183i\152;\208\219\173\v\158\EOT\177\SO\141-\245\172o\b\SUBt\230\161o\145-\SUBpd(\RS\219j*\231M \f\180~0.sc\ACK\184\&1\179\t\241U\222Cv\185\170\166\234\CAN\248\249\247\132\ENQ\216\EOT!p\152\f\196\DC1\140&~F[MV\187\SOH\196\250o\SO\167:\161\235~v.\154\159K\133L1#\135U\225\138\246bB\203\239\174\194y#\v\191\159\ACK\ACKQ@\171\DC3\250\220uLkPI\STX\SYNa\141\169\170\189&\DLE\b\150X\156\DC1\187\&6\236\182zN\152\230A\208\&3\255\v\210\RS\167\131\GSI\191I\207\188\242>\244\217VFE!\f\223\227BL\241)\198'\b\217S\253\184\183\197\143\144\140U\131\227?\208\199h}\134\188Y\180\180mr\186zZ\165&\165xZv\173I\178d\155_\EOTc\225;\187!Vx\181\138\158c\249\142$f\US\241\250\249\135\244<\EM\DLE\157"
+                }
+          , exactObjectRaw =
+              "0\130\STX\\\160\ETX\STX\SOH\STX\STX\ACK\SOH\130 \f\186=0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\RS\ETB\r220721091800Z\ETB\r270720091800Z0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\244\164\ru\139\141\238\131\212\176\157R+b\249\241\232\SOH\DLE\182\bZ\190\\E\223O^\229u\147[6\135;v\188\202\SIKY{\243\207\191\133V\248\n\214By\166\217\fV\US4\198\210\218\137[\132m:\SYN\180\189\250\155f\218\146\174qz\132\167\226\140\244Z3\152\175\234\159\191\160y\t{\184w\\OLQ\169\245J\227\165\171D\RS\DC2\241W[+\213\136+jk\n\241\200>\237N\245\225\254\155\216>\ESCV5\215\164H\168\162\134|f\236Y\216r5\142;\248\183\&1_4\225\129\215\226\224\DC3\240p\US\226+\245\255\139\138\141\141\238\ENQ,z\192%\SO\210\233\180bMs\242\191\186\189\&1\223zGT\253\133wE\ETX\219\"[\218\230\172\144\160\252}6\217:\234\199\a-\148\137\DLE\140\241\163\202\201\ENQ\222\240\156\194\226#\228\207\SI\184\253\251\147\160.\136\SYN]W\189\224\ESC\203|J\n\f\RS\DC1%Y\"\202\163\STX\ETX\SOH\NUL\SOH"
+          , encodeSignedObject =
+              "0\130\ETXt0\130\STX\\\160\ETX\STX\SOH\STX\STX\ACK\SOH\130 \f\186=0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\RS\ETB\r220721091800Z\ETB\r270720091800Z0{1\DC40\DC2\ACK\ETXU\EOT\n\DC3\vGoogle Inc.1\SYN0\DC4\ACK\ETXU\EOT\a\DC3\rMountain View1\SI0\r\ACK\ETXU\EOT\ETX\DC3\ACKGoogle1\CAN0\SYN\ACK\ETXU\EOT\v\DC3\SIGoogle For Work1\v0\t\ACK\ETXU\EOT\ACK\DC3\STXUS1\DC30\DC1\ACK\ETXU\EOT\b\DC3\nCalifornia0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\244\164\ru\139\141\238\131\212\176\157R+b\249\241\232\SOH\DLE\182\bZ\190\\E\223O^\229u\147[6\135;v\188\202\SIKY{\243\207\191\133V\248\n\214By\166\217\fV\US4\198\210\218\137[\132m:\SYN\180\189\250\155f\218\146\174qz\132\167\226\140\244Z3\152\175\234\159\191\160y\t{\184w\\OLQ\169\245J\227\165\171D\RS\DC2\241W[+\213\136+jk\n\241\200>\237N\245\225\254\155\216>\ESCV5\215\164H\168\162\134|f\236Y\216r5\142;\248\183\&1_4\225\129\215\226\224\DC3\240p\US\226+\245\255\139\138\141\141\238\ENQ,z\192%\SO\210\233\180bMs\242\191\186\189\&1\223zGT\253\133wE\ETX\219\"[\218\230\172\144\160\252}6\217:\234\199\a-\148\137\DLE\140\241\163\202\201\ENQ\222\240\156\194\226#\228\207\SI\184\253\251\147\160.\136\SYN]W\189\224\ESC\203|J\n\f\RS\DC1%Y\"\202\163\STX\ETX\SOH\NUL\SOH0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL\ETX\130\SOH\SOH\NUL\238\"\216Z\168\132\232\159\187\183i\152;\208\219\173\v\158\EOT\177\SO\141-\245\172o\b\SUBt\230\161o\145-\SUBpd(\RS\219j*\231M \f\180~0.sc\ACK\184\&1\179\t\241U\222Cv\185\170\166\234\CAN\248\249\247\132\ENQ\216\EOT!p\152\f\196\DC1\140&~F[MV\187\SOH\196\250o\SO\167:\161\235~v.\154\159K\133L1#\135U\225\138\246bB\203\239\174\194y#\v\191\159\ACK\ACKQ@\171\DC3\250\220uLkPI\STX\SYNa\141\169\170\189&\DLE\b\150X\156\DC1\187\&6\236\182zN\152\230A\208\&3\255\v\210\RS\167\131\GSI\191I\207\188\242>\244\217VFE!\f\223\227BL\241)\198'\b\217S\253\184\183\197\143\144\140U\131\227?\208\199h}\134\188Y\180\180mr\186zZ\165&\165xZv\173I\178d\155_\EOTc\225;\187!Vx\181\138\158c\249\142$f\US\241\250\249\135\244<\EM\DLE\157"
+          }
+      ]
   , nameIDFormats =
       [ "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" ]
   , singleSignOnServices =

--- a/tests/data/metadata/keycloak.xml.expected
+++ b/tests/data/metadata/keycloak.xml.expected
@@ -1,71 +1,80 @@
 IDPSSODescriptor
   { entityID = "https://sso.ja-sore.de/auth/realms/HERP"
-  , x509Certificate =
-      SignedExact
-        { getSigned =
-            Signed
-              { signedObject =
-                  Certificate
-                    { certVersion = 0
-                    , certSerial = 1611899272455
-                    , certSignatureAlg = SignatureALG HashSHA256 PubKeyALG_RSA
-                    , certIssuerDN =
-                        DistinguishedName
-                          { getDistinguishedElements =
-                              [ ( [ 2 , 5 , 4 , 3 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = UTF8
-                                    , getCharacterStringRawData = "HERP"
+  , x509Certificates =
+      [ SignedExact
+          { getSigned =
+              Signed
+                { signedObject =
+                    Certificate
+                      { certVersion = 0
+                      , certSerial = 1611899272455
+                      , certSignatureAlg = SignatureALG HashSHA256 PubKeyALG_RSA
+                      , certIssuerDN =
+                          DistinguishedName
+                            { getDistinguishedElements =
+                                [ ( [ 2 , 5 , 4 , 3 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = UTF8
+                                      , getCharacterStringRawData = "HERP"
+                                      }
+                                  )
+                                ]
+                            }
+                      , certValidity =
+                          ( DateTime
+                              { dtDate =
+                                  Date { dateYear = 2021 , dateMonth = January , dateDay = 29 }
+                              , dtTime =
+                                  TimeOfDay
+                                    { todHour = 5 h
+                                    , todMin = 46 m
+                                    , todSec = 12 s
+                                    , todNSec = 0 ns
                                     }
-                                )
-                              ]
-                          }
-                    , certValidity =
-                        ( DateTime
-                            { dtDate =
-                                Date { dateYear = 2021 , dateMonth = January , dateDay = 29 }
-                            , dtTime =
-                                TimeOfDay
-                                  { todHour = 5 h , todMin = 46 m , todSec = 12 s , todNSec = 0 ns }
-                            }
-                        , DateTime
-                            { dtDate =
-                                Date { dateYear = 2031 , dateMonth = January , dateDay = 29 }
-                            , dtTime =
-                                TimeOfDay
-                                  { todHour = 5 h , todMin = 47 m , todSec = 52 s , todNSec = 0 ns }
-                            }
-                        )
-                    , certSubjectDN =
-                        DistinguishedName
-                          { getDistinguishedElements =
-                              [ ( [ 2 , 5 , 4 , 3 ]
-                                , ASN1CharacterString
-                                    { characterEncoding = UTF8
-                                    , getCharacterStringRawData = "HERP"
+                              }
+                          , DateTime
+                              { dtDate =
+                                  Date { dateYear = 2031 , dateMonth = January , dateDay = 29 }
+                              , dtTime =
+                                  TimeOfDay
+                                    { todHour = 5 h
+                                    , todMin = 47 m
+                                    , todSec = 52 s
+                                    , todNSec = 0 ns
                                     }
-                                )
-                              ]
-                          }
-                    , certPubKey =
-                        PubKeyRSA
-                          PublicKey
-                            { public_size = 256
-                            , public_n =
-                                26794629232301390559329251866062548351573676959105948670047115599484903764153173211872085488745203643849524181464124430648664560428395941550339690556064181777927415101879096439027796505139145202723504898654935482393722978364774771646139306434335595822802292206982564879345724045673514452796802353368762193429772204243864488315862304970769841689431483551389268024017379114959044330977741690398490550580701831871711628065022359440646669330356587937408829251700791982308190330679272353052846282673680829331107723412188694305482396334605009242290197499924909025290277992294341810791131897406148044363907966374411188642337
-                            , public_e = 65537
+                              }
+                          )
+                      , certSubjectDN =
+                          DistinguishedName
+                            { getDistinguishedElements =
+                                [ ( [ 2 , 5 , 4 , 3 ]
+                                  , ASN1CharacterString
+                                      { characterEncoding = UTF8
+                                      , getCharacterStringRawData = "HERP"
+                                      }
+                                  )
+                                ]
                             }
-                    , certExtensions = Extensions Nothing
-                    }
-              , signedAlg = SignatureALG HashSHA256 PubKeyALG_RSA
-              , signedSignature =
-                  "\204i\244\225\204\252\161\166hE@\168\232\226\161s\a\206J\184\232\141\250\155S\NAK\188d\ACK:P\245\NAK\240\135\192m\172L\149\206#\212\213j\221\172\"\251 \137X\176\218g#\151\226d2\SI\227h\FS\RSC\215\250\144\139\252\v\ACKH=L\155v\194\158\140\142C\143\175\t\r\242[\225i\186\188R\205\141\136\EM\225\US2\227Y\172%\182'\189\175U\180\166\232\DC1\ESC\138\146f\242j\162\194I\135\213\171\210o\f\157\163\246\240\254\223\167\130\DEL\143u\NUL\138\249Ff\245\215\135Y\FS\151\249QZ\SUB\CAN\170dw\175h\253\240\229\178\253gX\DEL\US\232<\208\214\&1\210Cu\USH\254\171e9Q\236\136@\207\241\158;\243\252\253!\140\RS9\134*\131\179\174\239\182,\255\145\186\193\FSQ\v\ACK\148\140\192\207tW\242\189\245\SOHg\209\ENQ\165\133\NAK\212o\243^\225\144\193\251\161\219\177\150\207\200\&2\181\215u\188<ASN\161\223"
-              }
-        , exactObjectRaw =
-            "0\130\SOH\DEL\STX\ACK\SOHwL\174\253\a0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\RS\ETB\r210129054612Z\ETB\r310129054752Z0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\212A\GS\ETX*\ETBo\160\236*\196K,\235\191\225\239\194;\200v\ETBYYg:\207\129\162\SI|\205\213\&1>q\184|\240\147\DC4\173T\214w\177\t.\175\189\184\ACK\179\v&_\205~Au\171\131\170\202~,\255s\219\CAN\137\233\153Z\163\\\249\201\199\198\225\220/\DLE\137N\191\138\215\215\&4\157\182\r\249\v?\144u\165\US\"@\132_wS\FS\142\221\NAK\204(\187\227^\151@F\nzu\239\SI T\243\129\EM\140\239:\208`Y\195U\247\239Y\154~\232I\SUB\ACK\229\RS.G8f>\253v\167\"\145;\253!f\190\160ND5\212+'\201\245\188\247F\195\&3NH\230o \r=\US\NUL\237\143\206v\208!\STX\130\150\165(\200\214\201e\176^\SI%{A\161$\144/\rrK\232\235/\155i\239(\DLE_i\197\b\151\ENQ^\221\RS\214<T\181\170\229#v!\229\245T\174}\132\200\&65\209\212\198\&3\EM\"!\STX\ETX\SOH\NUL\SOH"
-        , encodeSignedObject =
-            "0\130\STX\151\&0\130\SOH\DEL\STX\ACK\SOHwL\174\253\a0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\RS\ETB\r210129054612Z\ETB\r310129054752Z0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\212A\GS\ETX*\ETBo\160\236*\196K,\235\191\225\239\194;\200v\ETBYYg:\207\129\162\SI|\205\213\&1>q\184|\240\147\DC4\173T\214w\177\t.\175\189\184\ACK\179\v&_\205~Au\171\131\170\202~,\255s\219\CAN\137\233\153Z\163\\\249\201\199\198\225\220/\DLE\137N\191\138\215\215\&4\157\182\r\249\v?\144u\165\US\"@\132_wS\FS\142\221\NAK\204(\187\227^\151@F\nzu\239\SI T\243\129\EM\140\239:\208`Y\195U\247\239Y\154~\232I\SUB\ACK\229\RS.G8f>\253v\167\"\145;\253!f\190\160ND5\212+'\201\245\188\247F\195\&3NH\230o \r=\US\NUL\237\143\206v\208!\STX\130\150\165(\200\214\201e\176^\SI%{A\161$\144/\rrK\232\235/\155i\239(\DLE_i\197\b\151\ENQ^\221\RS\214<T\181\170\229#v!\229\245T\174}\132\200\&65\209\212\198\&3\EM\"!\STX\ETX\SOH\NUL\SOH0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL\ETX\130\SOH\SOH\NUL\204i\244\225\204\252\161\166hE@\168\232\226\161s\a\206J\184\232\141\250\155S\NAK\188d\ACK:P\245\NAK\240\135\192m\172L\149\206#\212\213j\221\172\"\251 \137X\176\218g#\151\226d2\SI\227h\FS\RSC\215\250\144\139\252\v\ACKH=L\155v\194\158\140\142C\143\175\t\r\242[\225i\186\188R\205\141\136\EM\225\US2\227Y\172%\182'\189\175U\180\166\232\DC1\ESC\138\146f\242j\162\194I\135\213\171\210o\f\157\163\246\240\254\223\167\130\DEL\143u\NUL\138\249Ff\245\215\135Y\FS\151\249QZ\SUB\CAN\170dw\175h\253\240\229\178\253gX\DEL\US\232<\208\214\&1\210Cu\USH\254\171e9Q\236\136@\207\241\158;\243\252\253!\140\RS9\134*\131\179\174\239\182,\255\145\186\193\FSQ\v\ACK\148\140\192\207tW\242\189\245\SOHg\209\ENQ\165\133\NAK\212o\243^\225\144\193\251\161\219\177\150\207\200\&2\181\215u\188<ASN\161\223"
-        }
+                      , certPubKey =
+                          PubKeyRSA
+                            PublicKey
+                              { public_size = 256
+                              , public_n =
+                                  26794629232301390559329251866062548351573676959105948670047115599484903764153173211872085488745203643849524181464124430648664560428395941550339690556064181777927415101879096439027796505139145202723504898654935482393722978364774771646139306434335595822802292206982564879345724045673514452796802353368762193429772204243864488315862304970769841689431483551389268024017379114959044330977741690398490550580701831871711628065022359440646669330356587937408829251700791982308190330679272353052846282673680829331107723412188694305482396334605009242290197499924909025290277992294341810791131897406148044363907966374411188642337
+                              , public_e = 65537
+                              }
+                      , certExtensions = Extensions Nothing
+                      }
+                , signedAlg = SignatureALG HashSHA256 PubKeyALG_RSA
+                , signedSignature =
+                    "\204i\244\225\204\252\161\166hE@\168\232\226\161s\a\206J\184\232\141\250\155S\NAK\188d\ACK:P\245\NAK\240\135\192m\172L\149\206#\212\213j\221\172\"\251 \137X\176\218g#\151\226d2\SI\227h\FS\RSC\215\250\144\139\252\v\ACKH=L\155v\194\158\140\142C\143\175\t\r\242[\225i\186\188R\205\141\136\EM\225\US2\227Y\172%\182'\189\175U\180\166\232\DC1\ESC\138\146f\242j\162\194I\135\213\171\210o\f\157\163\246\240\254\223\167\130\DEL\143u\NUL\138\249Ff\245\215\135Y\FS\151\249QZ\SUB\CAN\170dw\175h\253\240\229\178\253gX\DEL\US\232<\208\214\&1\210Cu\USH\254\171e9Q\236\136@\207\241\158;\243\252\253!\140\RS9\134*\131\179\174\239\182,\255\145\186\193\FSQ\v\ACK\148\140\192\207tW\242\189\245\SOHg\209\ENQ\165\133\NAK\212o\243^\225\144\193\251\161\219\177\150\207\200\&2\181\215u\188<ASN\161\223"
+                }
+          , exactObjectRaw =
+              "0\130\SOH\DEL\STX\ACK\SOHwL\174\253\a0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\RS\ETB\r210129054612Z\ETB\r310129054752Z0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\212A\GS\ETX*\ETBo\160\236*\196K,\235\191\225\239\194;\200v\ETBYYg:\207\129\162\SI|\205\213\&1>q\184|\240\147\DC4\173T\214w\177\t.\175\189\184\ACK\179\v&_\205~Au\171\131\170\202~,\255s\219\CAN\137\233\153Z\163\\\249\201\199\198\225\220/\DLE\137N\191\138\215\215\&4\157\182\r\249\v?\144u\165\US\"@\132_wS\FS\142\221\NAK\204(\187\227^\151@F\nzu\239\SI T\243\129\EM\140\239:\208`Y\195U\247\239Y\154~\232I\SUB\ACK\229\RS.G8f>\253v\167\"\145;\253!f\190\160ND5\212+'\201\245\188\247F\195\&3NH\230o \r=\US\NUL\237\143\206v\208!\STX\130\150\165(\200\214\201e\176^\SI%{A\161$\144/\rrK\232\235/\155i\239(\DLE_i\197\b\151\ENQ^\221\RS\214<T\181\170\229#v!\229\245T\174}\132\200\&65\209\212\198\&3\EM\"!\STX\ETX\SOH\NUL\SOH"
+          , encodeSignedObject =
+              "0\130\STX\151\&0\130\SOH\DEL\STX\ACK\SOHwL\174\253\a0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\RS\ETB\r210129054612Z\ETB\r310129054752Z0\SI1\r0\v\ACK\ETXU\EOT\ETX\f\EOTHERP0\130\SOH\"0\r\ACK\t*\134H\134\247\r\SOH\SOH\SOH\ENQ\NUL\ETX\130\SOH\SI\NUL0\130\SOH\n\STX\130\SOH\SOH\NUL\212A\GS\ETX*\ETBo\160\236*\196K,\235\191\225\239\194;\200v\ETBYYg:\207\129\162\SI|\205\213\&1>q\184|\240\147\DC4\173T\214w\177\t.\175\189\184\ACK\179\v&_\205~Au\171\131\170\202~,\255s\219\CAN\137\233\153Z\163\\\249\201\199\198\225\220/\DLE\137N\191\138\215\215\&4\157\182\r\249\v?\144u\165\US\"@\132_wS\FS\142\221\NAK\204(\187\227^\151@F\nzu\239\SI T\243\129\EM\140\239:\208`Y\195U\247\239Y\154~\232I\SUB\ACK\229\RS.G8f>\253v\167\"\145;\253!f\190\160ND5\212+'\201\245\188\247F\195\&3NH\230o \r=\US\NUL\237\143\206v\208!\STX\130\150\165(\200\214\201e\176^\SI%{A\161$\144/\rrK\232\235/\155i\239(\DLE_i\197\b\151\ENQ^\221\RS\214<T\181\170\229#v!\229\245T\174}\132\200\&65\209\212\198\&3\EM\"!\STX\ETX\SOH\NUL\SOH0\r\ACK\t*\134H\134\247\r\SOH\SOH\v\ENQ\NUL\ETX\130\SOH\SOH\NUL\204i\244\225\204\252\161\166hE@\168\232\226\161s\a\206J\184\232\141\250\155S\NAK\188d\ACK:P\245\NAK\240\135\192m\172L\149\206#\212\213j\221\172\"\251 \137X\176\218g#\151\226d2\SI\227h\FS\RSC\215\250\144\139\252\v\ACKH=L\155v\194\158\140\142C\143\175\t\r\242[\225i\186\188R\205\141\136\EM\225\US2\227Y\172%\182'\189\175U\180\166\232\DC1\ESC\138\146f\242j\162\194I\135\213\171\210o\f\157\163\246\240\254\223\167\130\DEL\143u\NUL\138\249Ff\245\215\135Y\FS\151\249QZ\SUB\CAN\170dw\175h\253\240\229\178\253gX\DEL\US\232<\208\214\&1\210Cu\USH\254\171e9Q\236\136@\207\241\158;\243\252\253!\140\RS9\134*\131\179\174\239\182,\255\145\186\193\FSQ\v\ACK\148\140\192\207tW\242\189\245\SOHg\209\ENQ\165\133\NAK\212o\243^\225\144\193\251\161\219\177\150\207\200\&2\181\215u\188<ASN\161\223"
+          }
+      ]
   , nameIDFormats =
       [ "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
       , "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"


### PR DESCRIPTION
**Summary**

I realised that when an IdP is about to rotate their certificates, their IdP metadata may contain more than one certificate.
This PR changes the `x509Certificate` to `x509Certificates :: [X509.SignedExact X509.Certificate]` so that it doesn't drop extra certificates.

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
