### PR TITLE
Request: fix a bug that causes `renderXML` to crash

### DIFF
--- a/src/Network/Wai/SAML2/Request.hs
+++ b/src/Network/Wai/SAML2/Request.hs
@@ -33,6 +33,7 @@ module Network.Wai.SAML2.Request (
 
 import Crypto.Random
 
+import Data.Foldable (toList)
 import Data.Time.Clock
 
 import Network.Wai.SAML2.NameIDFormat
@@ -132,7 +133,7 @@ renderXML AuthnRequest{..} =
                 , ("AssertionConsumerServiceIndex", "1") -- [AuthnRequest]
                 ]
                 -- [RequestAbstractType]
-                ++ [("Destination", uri) | let Just uri = authnRequestDestination] ))
+                ++ [("Destination", uri) | uri <- toList authnRequestDestination] ))
             [NodeElement issuer, NodeElement nameIdPolicy]
         -- Reference [RequestAbstractType]
         issuer = Element


### PR DESCRIPTION
**Summary**

This fixes the bug causing `renderXML` to crash when `authnRequestDestination` is Nothing

<!-- Summarise what changes your PR makes and why. -->

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
