### PR TITLE
handle multiple attribute values with the same name instead of concatenating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7
 
 -   Replaced `x509Certificate` with `x509Certificates` in `IDPSSODescriptor` so that it may have more than one certificate ([#65](https://github.com/mbg/wai-saml2/pull/65) by [@fumieval](https://github.com/fumieval))
+-   Added `attributeValues` to `AssertionAttribute` in order to handle multiple attribute values with the same name ([#67](https://github.com/mbg/wai-saml2/pull/67) by [@fumieval](https://github.com/fumieval))
 
 ## 0.6
 

--- a/src/Network/Wai/SAML2/Assertion.hs
+++ b/src/Network/Wai/SAML2/Assertion.hs
@@ -230,19 +230,24 @@ data AssertionAttribute = AssertionAttribute {
     attributeFriendlyName :: !(Maybe T.Text),
     -- | The name format.
     attributeNameFormat :: !T.Text,
+    -- | The value of the attribute, concatened from the 'attributeValues'.
+    attributeValue :: !T.Text,
     -- | The value of the attribute.
-    attributeValue :: !T.Text
+    --
+    -- @since 0.7
+    attributeValues :: ![T.Text]
 } deriving (Eq, Show)
 
 instance FromXML AssertionAttribute where
     parseXML cursor = do
+        let attributeValues = cursor $/ element (saml2Name "AttributeValue") &/ content
         pure AssertionAttribute{
             attributeName = T.concat $ attribute "Name" cursor,
             attributeFriendlyName =
                 toMaybeText $ attribute "FriendlyName" cursor,
             attributeNameFormat = T.concat $ attribute "NameFormat" cursor,
-            attributeValue = T.concat $
-                cursor $/ element (saml2Name "AttributeValue") &/ content
+            attributeValue = T.concat attributeValues,
+            attributeValues = attributeValues
         }
 
 -- | SAML2 assertion statements (collections of assertion attributes).

--- a/src/Network/Wai/SAML2/Assertion.hs
+++ b/src/Network/Wai/SAML2/Assertion.hs
@@ -232,7 +232,7 @@ data AssertionAttribute = AssertionAttribute {
     attributeNameFormat :: !T.Text,
     -- | The value of the attribute, concatened from the 'attributeValues'.
     attributeValue :: !T.Text,
-    -- | The value of the attribute.
+    -- | The values of the attribute.
     --
     -- @since 0.7
     attributeValues :: ![T.Text]


### PR DESCRIPTION
**Summary**

For example, this allows having multiple role attributes assigned to one user. (Otherwise role names are literally concatenated, which is a rather surprising behaviour)

**Checklist**

- [x] All definitions are documented with Haddock-style comments.
- [x] All exported definitions have `@since` annotations.
- [x] Code is formatted in line with the existing code.
- [x] The changelog has been updated.
